### PR TITLE
Make Java version become Java provider

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -74,8 +74,8 @@ body:
   - type: input
     id: java
     attributes:
-      label: Java version
-      placeholder: 'Example: Java 16'
+      label: Java Provider
+      placeholder: 'Example: Termurin'
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -74,8 +74,8 @@ body:
   - type: input
     id: java
     attributes:
-      label: Java Provider
-      placeholder: 'Example: Termurin'
+      label: Java Provider + Version
+      placeholder: 'Example: Eclipse Termurin 17.0.6'
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -59,8 +59,8 @@ body:
   - type: input
     id: java
     attributes:
-      label: Java provider
-      placeholder: 'Example: Temurin'
+      label: Java Provider + Version
+      placeholder: 'Example: Eclipse Termurin 17.0.6'
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -59,8 +59,8 @@ body:
   - type: input
     id: java
     attributes:
-      label: Java version
-      placeholder: 'Example: Java 17'
+      label: Java provider
+      placeholder: 'Example: Temurin'
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
We should really be looking at the provider vs Java version in these reports, as we can easily check what version of Java the person is using as it gets logged along with mods. If the person isn't providing something that is listing their mods, theres something wrong with their report. There shouldn't be too many differences between providers like OpenJDK, Oracle, Azul, and Temurin, but there are differences, and some have more features unlocked for certain versions than others, or may optimize differently, like Oracle's GraalVM JDK version.