### PR TITLE
Fix a typo found when remapping fails and reword it.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
@@ -553,7 +553,7 @@ object KiltRemapper {
         logger.info("Finished remapping mods!")
 
         if (exception.suppressed.isNotEmpty()) {
-            logger.error("Ran into some errors, we're not going to continue with the repairing process.")
+            logger.error("Ran into some errors during the remapping process, cannot continue!")
             throw exception
         }
     }


### PR DESCRIPTION
typo from repairing -> remapping + reword