### PR TITLE
Fire the Forge BreakEvent.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/level/ServerPlayerGameModeInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/level/ServerPlayerGameModeInject.java
@@ -7,6 +7,7 @@ import com.llamalad7.mixinextras.sugar.Cancellable;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -42,17 +43,19 @@ public abstract class ServerPlayerGameModeInject {
 			at = @At(
 					value = "INVOKE",
 					target = "Lnet/minecraft/world/item/Item;canAttackBlock(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/player/Player;)Z"
-			) // We want to use WrapOperation or Redirect to ensure canAttackBlock is not fired more than once (it might have side effects).
+			)
 	)
-	public boolean canMine(
+	private boolean kilt$canAttackBlock(
 			Item instance, BlockState state, Level level, BlockPos pos, Player player, Operation<Boolean> original,
 			@Cancellable CallbackInfoReturnable<Boolean> cir, @Share("exp") LocalIntRef exp
 	) {
-		int expLocal = ForgeHooks.onBlockBreakEvent(level, gameModeForPlayer, this.player, pos);
+		int expLocal = ForgeHooks.kilt$onBlockBreakEvent(
+				level, gameModeForPlayer, this.player, pos,
+				() -> original.call(instance, state, level, pos, player)
+		);
 		if (expLocal == -1) {
-			// When the player's main hand item is empty, the game seems to ignore the value returned by the mixin and breaks the block anyway.
-			// Might only affect certain hardware.
-			if (player.getMainHandItem().isEmpty()) {
+			// Patch for porting lib still breaking block when event is cancelled with an empty main hand item.
+			if (FabricLoader.getInstance().isModLoaded("porting_lib_base") && player.getMainHandItem().isEmpty()) {
 				cir.setReturnValue(false);
 			}
 			return false;
@@ -68,7 +71,7 @@ public abstract class ServerPlayerGameModeInject {
 					shift = At.Shift.BEFORE // Necessary to capture variables.
 			)
 	)
-	public void dropXP(
+	private void kilt$dropXP(
 			BlockPos pos, CallbackInfoReturnable<Boolean> cir,
 			@Local BlockState blockState,
 			@Local(ordinal = 0) boolean removed, @Share("exp") LocalIntRef exp

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/level/ServerPlayerGameModeInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/level/ServerPlayerGameModeInject.java
@@ -38,7 +38,7 @@ public abstract class ServerPlayerGameModeInject {
 	@Shadow
 	protected ServerLevel level;
 
-	@WrapOperation(
+	/*@WrapOperation(
 			method = "destroyBlock",
 			at = @At(
 					value = "INVOKE",
@@ -79,6 +79,6 @@ public abstract class ServerPlayerGameModeInject {
 		if (removed && exp.get() > 0) {
 			blockState.getBlock().popExperience(level, pos, exp.get());
 		}
-	}
+	}*/
 
 }

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/level/ServerPlayerGameModeInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/level/ServerPlayerGameModeInject.java
@@ -1,10 +1,81 @@
 // TRACKED HASH: 6b790991592a47c6c6a8e8be25116c80e58fd91d
 package xyz.bluspring.kilt.forgeinjects.server.level;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Cancellable;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.ServerPlayerGameMode;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.ForgeHooks;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ServerPlayerGameMode.class)
 public abstract class ServerPlayerGameModeInject {
+
+	@Shadow
+	private GameType gameModeForPlayer;
+
+	@Shadow
+	@Final
+	protected ServerPlayer player;
+
+	@Shadow
+	protected ServerLevel level;
+
+	@WrapOperation(
+			method = "destroyBlock",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/world/item/Item;canAttackBlock(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/player/Player;)Z"
+			) // We want to use WrapOperation or Redirect to ensure canAttackBlock is not fired more than once (it might have side effects).
+	)
+	public boolean canMine(
+			Item instance, BlockState state, Level level, BlockPos pos, Player player, Operation<Boolean> original,
+			@Cancellable CallbackInfoReturnable<Boolean> cir, @Share("exp") LocalIntRef exp
+	) {
+		int expLocal = ForgeHooks.onBlockBreakEvent(level, gameModeForPlayer, this.player, pos);
+		if (expLocal == -1) {
+			// When the player's main hand item is empty, the game seems to ignore the value returned by the mixin and breaks the block anyway.
+			// Might only affect certain hardware.
+			if (player.getMainHandItem().isEmpty()) {
+				cir.setReturnValue(false);
+			}
+			return false;
+		}
+		exp.set(expLocal);
+		return true;
+	}
+
+	@Inject(
+			method = "destroyBlock",
+			at = @At(
+					value = "TAIL",
+					shift = At.Shift.BEFORE // Necessary to capture variables.
+			)
+	)
+	public void dropXP(
+			BlockPos pos, CallbackInfoReturnable<Boolean> cir,
+			@Local BlockState blockState,
+			@Local(ordinal = 0) boolean removed, @Share("exp") LocalIntRef exp
+	) {
+		if (removed && exp.get() > 0) {
+			blockState.getBlock().popExperience(level, pos, exp.get());
+		}
+	}
 
 }

--- a/src/main/kotlin/xyz/bluspring/kilt/Kilt.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/Kilt.kt
@@ -10,6 +10,7 @@ import io.github.fabricators_of_create.porting_lib.core.event.BaseEvent
 import io.github.fabricators_of_create.porting_lib.entity.events.CriticalHitEvent
 import io.github.fabricators_of_create.porting_lib.entity.events.LivingEntityEvents
 import io.github.fabricators_of_create.porting_lib.entity.events.PlayerInteractionEvents
+import io.github.fabricators_of_create.porting_lib.event.common.BlockEvents
 import io.github.fabricators_of_create.porting_lib.event.common.ExplosionEvents
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents
@@ -19,10 +20,12 @@ import net.minecraft.core.BlockPos
 import net.minecraft.world.InteractionResult
 import net.minecraft.world.item.context.UseOnContext
 import net.minecraft.world.level.ChunkPos
+import net.minecraft.world.level.Level
 import net.minecraft.world.phys.BlockHitResult
 import net.minecraftforge.common.ForgeHooks
 import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.event.ForgeEventFactory
+import net.minecraftforge.event.level.BlockEvent
 import net.minecraftforge.event.level.LevelEvent
 import net.minecraftforge.eventbus.api.Event
 import net.minecraftforge.server.ServerLifecycleHooks
@@ -153,6 +156,20 @@ class Kilt : ModInitializer {
             ForgeEventFactory.onExplosionDetonate(level, explosion, entities, diameter)
         }
 
+		BlockEvents.BLOCK_BREAK.register { event ->
+			val level = event.level
+			if (level is Level) {
+				val forgeEvent = BlockEvent.BreakEvent(level, event.pos, event.state, event.player);
+				forgeEvent.expToDrop = event.expToDrop
+				forgeEvent.isCanceled = event.isCanceled
+				forgeEvent.result = portingLibToEventBus(event.result)
+				MinecraftForge.EVENT_BUS.post(forgeEvent)
+				event.isCanceled = forgeEvent.isCanceled
+				event.expToDrop = forgeEvent.expToDrop
+				event.result = eventBusToPortingLib(forgeEvent.result)
+			}
+		}
+
         EntityEvent.ENTER_SECTION.register { entity, sectionX, sectionY, sectionZ, prevX, prevY, prevZ ->
             ForgeHooks.onEntityEnterSection(entity, ChunkPos.asLong(BlockPos(sectionX, sectionY, sectionZ)), ChunkPos.asLong(
                 BlockPos(prevX, prevY, prevZ)
@@ -224,6 +241,24 @@ class Kilt : ModInitializer {
                 KiltClient.lateRegisterEvents()
             }
         }
+
+		fun portingLibToEventBus(result: BaseEvent.Result): Event.Result {
+			return when (result) {
+				BaseEvent.Result.ALLOW -> Event.Result.ALLOW
+				BaseEvent.Result.DEFAULT -> Event.Result.DEFAULT
+				BaseEvent.Result.DENY -> Event.Result.DENY
+				else -> Event.Result.DEFAULT
+			}
+		}
+
+		fun eventBusToPortingLib(result: Event.Result): BaseEvent.Result {
+			return when (result) {
+				Event.Result.ALLOW -> BaseEvent.Result.ALLOW
+				Event.Result.DEFAULT -> BaseEvent.Result.DEFAULT
+				Event.Result.DENY -> BaseEvent.Result.DENY
+				else -> BaseEvent.Result.DEFAULT
+			}
+		}
 
         fun eventBusToArchitectury(result: Event.Result): EventResult {
             return when (result) {


### PR DESCRIPTION
This patch makes Kilt fire the Forge BreakEvent. This event is fired before a player tries to break a block, giving mods accepting the event the option to cancel the event (this leaving the block intact) or set an arbitrary amount of xp to drop if the block was successfully broken.

This patch is important for [Stargate Journey](https://modrinth.com/mod/sgjourney), as otherwise it is effectively impossible to remove frame cover blocks from the stargate.

For some reason, the game seems to ignore the return value of the WrapOperation mixin around canAttackBlock whenever the player's main hand is empty. I don't know why this happens, but I'm guessing it's related to some optimisation happening behind the scenes (branch prediction maybe?). This is why I added the CallbackInfoReturnable.

For the second injection I unfortunately had to use a shift statement because it simply could not find the local variables from the TAIL position otherwise.

For now this mixin uses the default priority (999). Something I was considering was to set the priority parameter even lower since any other mods wrapping canAttackBlock with a lower value of the priority parameter would be silently ignored. This could also be resolved by writing a custom version of ForgeHooks::onBlockBreakEvent which takes the callback as an argument, but then this would have to be updated manually whenever it the original Forge method is changed.