### PR TITLE
Improve mod compatibility of re-equip check.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/client/renderer/ItemInHandRendererInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/client/renderer/ItemInHandRendererInject.java
@@ -26,6 +26,7 @@ import net.minecraftforge.client.extensions.common.IClientItemExtensions;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -37,10 +38,6 @@ public abstract class ItemInHandRendererInject {
     @Shadow private ItemStack mainHandItem;
 
     @Shadow private ItemStack offHandItem;
-
-    @Shadow private float mainHandHeight;
-
-    @Shadow private float offHandHeight;
 
     @WrapWithCondition(method = "renderHandsWithItems", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/ItemInHandRenderer;renderArmWithItem(Lnet/minecraft/client/player/AbstractClientPlayer;FFLnet/minecraft/world/InteractionHand;FLnet/minecraft/world/item/ItemStack;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V"))
     private boolean kilt$cancelRenderIfEventCancelled(ItemInHandRenderer instance, AbstractClientPlayer player, float partialTicks, float pitch, InteractionHand hand, float swingProgress, ItemStack stack, float equippedProgress, PoseStack poseStack, MultiBufferSource buffer, int combinedLight) {
@@ -64,12 +61,20 @@ public abstract class ItemInHandRendererInject {
             this.offHandItem = offhandStack;
     }
 
+	@Unique
+	private static boolean kilt$shouldSkipReequip(boolean fabricSkipReequip, boolean forgeSkipReequip) {
+		if (forgeSkipReequip) {
+			return true;
+		}
+		return fabricSkipReequip;
+	}
+
     @Definition(id = "mainHandItem", field = "Lnet/minecraft/client/renderer/ItemInHandRenderer;mainHandItem:Lnet/minecraft/world/item/ItemStack;")
     @Definition(id = "itemStack", local = @Local(type = ItemStack.class, ordinal = 0))
     @Expression("this.mainHandItem == itemStack")
     @ModifyExpressionValue(method = "tick", at = @At("MIXINEXTRAS:EXPRESSION"))
     private boolean kilt$useReequipCheckForMainHand(boolean original, @Share("reequipM") LocalBooleanRef reequipM) {
-		return !reequipM.get();
+		return kilt$shouldSkipReequip(original, !reequipM.get());
     }
 
 	@Definition(id = "offHandItem", field = "Lnet/minecraft/client/renderer/ItemInHandRenderer;offHandItem:Lnet/minecraft/world/item/ItemStack;")
@@ -77,7 +82,7 @@ public abstract class ItemInHandRendererInject {
 	@Expression("this.offHandItem == itemStack2")
 	@ModifyExpressionValue(method = "tick", at = @At("MIXINEXTRAS:EXPRESSION"))
 	private boolean kilt$useReequipCheckForOffHand(boolean original, @Share("reequipO") LocalBooleanRef reequipO) {
-		return !reequipO.get();
+		return kilt$shouldSkipReequip(original, !reequipO.get());
 	}
 
     @WrapOperation(method = "renderArmWithItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;is(Lnet/minecraft/world/item/Item;)Z", ordinal = 1))

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/client/renderer/ItemInHandRendererInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/client/renderer/ItemInHandRendererInject.java
@@ -1,6 +1,8 @@
 // TRACKED HASH: b73c34d168c602ac81d45109572d392b4ad484f8
 package xyz.bluspring.kilt.forgeinjects.client.renderer;
 
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
@@ -26,7 +28,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ItemInHandRenderer.class)
@@ -63,31 +64,24 @@ public abstract class ItemInHandRendererInject {
             this.offHandItem = offhandStack;
     }
 
-    // TODO: implement when ternaries are fixed in MixinExtras
-    /*@Definition(id = "mainHandItem", field = "Lnet/minecraft/client/renderer/ItemInHandRenderer;mainHandItem:Lnet/minecraft/world/item/ItemStack;")
-    @Definition(id = "itemStack", local = @Local)
+    @Definition(id = "mainHandItem", field = "Lnet/minecraft/client/renderer/ItemInHandRenderer;mainHandItem:Lnet/minecraft/world/item/ItemStack;")
+    @Definition(id = "itemStack", local = @Local(type = ItemStack.class, ordinal = 0))
     @Expression("this.mainHandItem == itemStack")
     @ModifyExpressionValue(method = "tick", at = @At("MIXINEXTRAS:EXPRESSION"))
-    private boolean kilt$useReequipCheckForMainHand(boolean original) {
+    private boolean kilt$useReequipCheckForMainHand(boolean original, @Share("reequipM") LocalBooleanRef reequipM) {
+		return !reequipM.get();
+    }
 
-    }*/
+	@Definition(id = "offHandItem", field = "Lnet/minecraft/client/renderer/ItemInHandRenderer;offHandItem:Lnet/minecraft/world/item/ItemStack;")
+	@Definition(id = "itemStack2", local = @Local(type = ItemStack.class, ordinal = 1))
+	@Expression("this.offHandItem == itemStack2")
+	@ModifyExpressionValue(method = "tick", at = @At("MIXINEXTRAS:EXPRESSION"))
+	private boolean kilt$useReequipCheckForOffHand(boolean original, @Share("reequipO") LocalBooleanRef reequipO) {
+		return !reequipO.get();
+	}
 
     @WrapOperation(method = "renderArmWithItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;is(Lnet/minecraft/world/item/Item;)Z", ordinal = 1))
     private boolean kilt$useCrossbowInstanceOfCheck(ItemStack instance, Item item, Operation<Boolean> original) {
         return original.call(instance, item) || instance.getItem() instanceof CrossbowItem;
-    }
-
-    @ModifyExpressionValue(method = "tick", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/ItemInHandRenderer;mainHandItem:Lnet/minecraft/world/item/ItemStack;", ordinal = 2))
-    private ItemStack kilt$useReequipCheckForMainHand(ItemStack original, @Local(ordinal = 0) ItemStack itemStack, @Share("reequipM") LocalBooleanRef reequipM) {
-        if (reequipM.get()) {
-            return null;
-        } else {
-            return itemStack;
-        }
-    }
-
-    @ModifyArg(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Mth;clamp(FFF)F", ordinal = 3), index = 0)
-    private float kilt$useReequipCheckForOffHand(float original, @Share("reequipO") LocalBooleanRef reequipO) {
-        return (!reequipO.get() ? 1.0F : 0.0F) - this.offHandHeight;
     }
 }

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/client/renderer/ItemInHandRendererInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/client/renderer/ItemInHandRendererInject.java
@@ -1,6 +1,7 @@
 // TRACKED HASH: b73c34d168c602ac81d45109572d392b4ad484f8
 package xyz.bluspring.kilt.forgeinjects.client.renderer;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
@@ -76,10 +77,13 @@ public abstract class ItemInHandRendererInject {
         return original.call(instance, item) || instance.getItem() instanceof CrossbowItem;
     }
 
-    @ModifyArg(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Mth;clamp(FFF)F", ordinal = 2), index = 0)
-    private float kilt$useReequipCheckForMainHand(float original, @Share("reequipM") LocalBooleanRef reequipM, @Local LocalPlayer localPlayer) {
-        float f = localPlayer.getAttackStrengthScale(1.0F);
-        return (!reequipM.get() ? f * f * f : 0.0F) - this.mainHandHeight;
+    @ModifyExpressionValue(method = "tick", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/ItemInHandRenderer;mainHandItem:Lnet/minecraft/world/item/ItemStack;", ordinal = 2))
+    private ItemStack kilt$useReequipCheckForMainHand(ItemStack original, @Local(ordinal = 0) ItemStack itemStack, @Share("reequipM") LocalBooleanRef reequipM) {
+        if (reequipM.get()) {
+            return null;
+        } else {
+            return itemStack;
+        }
     }
 
     @ModifyArg(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Mth;clamp(FFF)F", ordinal = 3), index = 0)


### PR DESCRIPTION
This pull request makes the re-equip check slightly more inter-mod compatible.

You see, [Combatify](https://github.com/Alexandra-Myers/Combatify) and [CookeyMod](https://github.com/rizecookey/CookeyMod) have placed ModifyVariable mixins right in-between LocalPlayer::getAttackStrengthScale and Mth::clamp. When combined with Kilt, this causes an issue similar to Alexandra-Myers/Combatify#82 (important to note that the Kilt issue is different from 82 as Kilt was not present in the logs, but it shows similar symptoms).

I've double checked with a quickly thrown together test mod and it seems to continue working, but if you know any forge mods which has noticeable uses of this check then please let me know so I can test them as well.