### PR TITLE
Register TransferInterop to Forge event bus correctly

### DIFF
--- a/compat/transfer-api-compat/src/main/kotlin/xyz/bluspring/kilt/compat/transfer/TransferInterop.kt
+++ b/compat/transfer-api-compat/src/main/kotlin/xyz/bluspring/kilt/compat/transfer/TransferInterop.kt
@@ -26,7 +26,7 @@ import xyz.bluspring.kilt.compat.transfer.item.ForgeSlottedStorage
 
 class TransferInterop : ModInitializer {
     override fun onInitialize() {
-        MinecraftForge.EVENT_BUS.register(TransferInterop())
+        MinecraftForge.EVENT_BUS.register(this)
 
         ItemStorage.SIDED.registerFallback { world, pos, state, blockEntity, direction ->
             if (blockEntity == null)

--- a/compat/transfer-api-compat/src/main/kotlin/xyz/bluspring/kilt/compat/transfer/TransferInterop.kt
+++ b/compat/transfer-api-compat/src/main/kotlin/xyz/bluspring/kilt/compat/transfer/TransferInterop.kt
@@ -26,8 +26,7 @@ import xyz.bluspring.kilt.compat.transfer.item.ForgeSlottedStorage
 
 class TransferInterop : ModInitializer {
     override fun onInitialize() {
-        MinecraftForge.EVENT_BUS.register(::onAttachBlockEntityCapabilities)
-        MinecraftForge.EVENT_BUS.register(::onAttachItemStackCapabilities)
+        MinecraftForge.EVENT_BUS.register(TransferInterop())
 
         ItemStorage.SIDED.registerFallback { world, pos, state, blockEntity, direction ->
             if (blockEntity == null)


### PR DESCRIPTION
The event register before was not fired due to incorrect registration.
Should have register via object init instead of method.