### PR TITLE
Add some old deprecated IMCMessage getters.

### DIFF
--- a/src/main/kotlin/net/minecraftforge/fml/InterModComms.kt
+++ b/src/main/kotlin/net/minecraftforge/fml/InterModComms.kt
@@ -11,7 +11,29 @@ import java.util.stream.StreamSupport
 
 object InterModComms {
     @JvmRecord
-    data class IMCMessage(val senderModId: String, val modId: String, val method: String, val messageSupplier: Supplier<*>)
+    data class IMCMessage(val senderModId: String, val modId: String, val method: String, val messageSupplier: Supplier<*>) {
+
+        @Deprecated("use senderModId()")
+        fun getSenderModId(): String {
+            return this.senderModId
+        }
+
+        @Deprecated("use modId()")
+        fun getModId(): String {
+            return this.modId
+        }
+
+        @Deprecated("use method()")
+        fun getMethod(): String {
+            return this.method
+        }
+
+        @Deprecated("use messageSupplier()")
+        fun <T> getMessageSupplier(): Supplier<T> {
+            @Suppress("UNCHECKED_CAST")
+            return this.messageSupplier as Supplier<T>
+        }
+    }
 
     private val containerQueues = ConcurrentHashMap<String, ConcurrentLinkedQueue<IMCMessage>>()
     @JvmStatic


### PR DESCRIPTION
Some forge mods still use the old [IMCMessage getters](https://github.com/MinecraftForge/MinecraftForge/blob/1.20.1/fmlcore/src/main/java/net/minecraftforge/fml/InterModComms.java#L48) from before it was a record.

An example is [RFTools Utility](https://github.com/McJtyMods/RFToolsUtility/blob/1.20/src/main/java/mcjty/rftoolsutility/RFToolsUtility.java#L79), which currently breaks the loading process, crashing the game whenever you try to load a world.

Technically, only getMethod and getMessageSupplier should be necessary for RFTools Utility to work, but I thought I'd throw in the rest while I was at it. There could be other mods still using them after all.