### PR TITLE
Fix ClassCastException with create 6.0.8.1.

### DIFF
--- a/compat/create-compat/build.gradle.kts
+++ b/compat/create-compat/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    modImplementation("maven.modrinth:create-fabric:0.5.1-j-build.1631+mc1.20.1")
+    modImplementation("maven.modrinth:create-fabric:6.0.8.1+build.1744-mc1.20.1")
     modImplementation("io.github.tropheusj:milk-lib:1.2.60")
     modImplementation("com.tterrag.registrate_fabric:Registrate:1.3.79-MC1.20.1")
 

--- a/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/create_fabric/AllFluidsMixin.java
+++ b/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/create_fabric/AllFluidsMixin.java
@@ -1,0 +1,24 @@
+package xyz.bluspring.kilt.compat.create.mixin.create_fabric;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.simibubi.create.AllFluids;
+import io.github.fabricators_of_create.porting_lib.fluids.FluidType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(AllFluids.class)
+public class AllFluidsMixin {
+
+    @ModifyExpressionValue(
+            method = "<clinit>",
+            at = @At(
+                    value = "NEW",
+                    target = "io/github/fabricators_of_create/porting_lib/fluids/FluidType"
+            ),
+            require = 0 // Older versions of create-fabric won't have FluidType
+    )
+    private static FluidType kilt$wrapFluid(FluidType fluidType) {
+        return net.minecraftforge.fluids.FluidType.kilt$tryGetWrappingFluidType(fluidType);
+    }
+
+}

--- a/compat/create-compat/src/main/resources/kilt-create-compat.mixins.json
+++ b/compat/create-compat/src/main/resources/kilt-create-compat.mixins.json
@@ -4,6 +4,7 @@
     "package": "xyz.bluspring.kilt.compat.create.mixin",
     "compatibilityLevel": "JAVA_17",
     "mixins": [
+        "create_fabric.AllFluidsMixin",
         "create_fabric.CreateRegistrateMixin",
         "flywheel.BakedModelBuffererMixin",
         "registrate_fabric.AbstractRegistrateMixin",


### PR DESCRIPTION
In fabric-create version 6.0.8.1 (see Fabricators-of-Create/Create@64b6788) they added explicit porting-lib FluidType objects which replace the ones normally fetched by porting-lib's getFluidType function. Only problem is that Kilt replaces this function with one returning the forge FluidType, so you get a ClassCastException. The easiest way I know to reproduce the issue is to install Immersive Engineering, since that causes a crash when loading a world.

This pull request resolves this by simply wrapping each FluidType in the AllFluids class in with the Forge FluidType.

It should be noted that this replaces the fluid types built into create. Let me know if you think I should handle everything in the getTypeOf instead (to keep the normal create fluid types in the constants as-is), or if I should keep it but add a fallback just in case some create addon decide to add their own fluids with a mixin into getTypeOf.

The crash when loading Kilt with Immersive Enegineering and Fabric Create 6.0.8.1:
```
java.lang.ClassCastException: class io.github.fabricators_of_create.porting_lib.fluids.FluidType cannot be cast to class net.minecraftforge.fluids.FluidType (io.github.fabricators_of_create.porting_lib.fluids.FluidType and net.minecraftforge.fluids.FluidType are in unnamed module of loader 'knot' @1b604f19)
	at knot//net.minecraft.class_3611.getFluidType(class_3611.java)
	at knot//net.minecraftforge.fluids.FluidUtil.getFilledBucket(FluidUtil.java:677)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at knot//blusunrize.immersiveengineering.common.crafting.fluidaware.IngredientFluidStack.method_8105(IngredientFluidStack.java:65)
	at knot//blusunrize.immersiveengineering.common.crafting.ArcRecyclingCalculator$RecipeIterator.getRecycleCalculation(ArcRecyclingCalculator.java:206)
	at knot//blusunrize.immersiveengineering.common.crafting.ArcRecyclingCalculator$RecipeIterator.process(ArcRecyclingCalculator.java:173)
	at knot//blusunrize.immersiveengineering.common.crafting.ArcRecyclingCalculator.run(ArcRecyclingCalculator.java:68)
	at knot//blusunrize.immersiveengineering.common.crafting.ArcRecyclingCalculator$1.fillInRecipes(ArcRecyclingCalculator.java:134)
	at knot//blusunrize.immersiveengineering.common.crafting.ArcRecyclingCalculator$1.onServerStarted(ArcRecyclingCalculator.java:112)
	at blusunrize.immersiveengineering.common.crafting.__ArcRecyclingCalculator_1_onServerStarted_ServerStartedEvent.invoke(.dynamic)
	at knot//net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:48)
	at knot//net.minecraftforge.eventbus.EventBus.post(EventBus.java:302)
	at knot//net.minecraftforge.eventbus.EventBus.post(EventBus.java:288)
	at knot//net.minecraftforge.server.ServerLifecycleHooks.handleServerStarted(ServerLifecycleHooks.java:106)
	at knot//xyz.bluspring.kilt.Kilt.registerFabricEvents$lambda$10(Kilt.kt:132)
	at knot//net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents.lambda$static$2(ServerLifecycleEvents.java:49)
	at knot//net.minecraft.server.MinecraftServer.handler$zmp000$fabric-lifecycle-events-v1$afterSetupServer(MinecraftServer.java:3842)
	at knot//net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:650)
	at knot//net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:265)
	at java.base/java.lang.Thread.run(Thread.java:833)
```