### PR TITLE
Fix Striders dying in lava when Valkyrien Skies is installed.

### DIFF
--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/valkyrienskies/EntityMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/valkyrienskies/EntityMixin.java
@@ -3,67 +3,34 @@ package xyz.bluspring.kilt.compat.fabric.mixin.valkyrienskies;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import com.moulberry.mixinconstraints.annotations.IfModLoaded;
-import io.github.fabricators_of_create.porting_lib.fluids.PortingLibFluids;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
-import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.fluids.FluidType;
 import org.apache.commons.lang3.tuple.MutableTriple;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.lang.reflect.Field;
+import xyz.bluspring.kilt.Kilt;
 
 @IfModLoaded("valkyrienskies")
-@Mixin(value = Entity.class, priority = 999)
+@Mixin(value = Entity.class, priority = 1101)
 public class EntityMixin {
 
-    @Unique
-    private static final String KILT$ENTITY_INJECT = "xyz.bluspring.kilt.forgeinjects.world.entity.EntityInject";
+    @Dynamic("Valkyrien Skies will return this boolean from updateFluidHeightAndDoFluidPushing and bypass ModifyReturnValue")
+    @Shadow(remap = false)
+    private boolean valkyrienskies$fluidPushRet;
 
-    @Unique
-    private static Field kilt$vsFluidAABBField = null;
-
-    @Unique
-    private static Field kilt$vsFluidPushRetField = null;
-
-    // Field name is dynamically decorated by mixinextras.
-    // This was the best way I could think of to find it reliably.
-    @Unique
-    private static Field kilt$getVSFluidPushRetField() {
-        if (kilt$vsFluidPushRetField == null) {
-            for (var field : Entity.class.getDeclaredFields()) {
-                if (field.getType() == Boolean.TYPE && field.getName().endsWith("valkyrienskies$fluidPushRet")) {
-                    kilt$vsFluidPushRetField = field;
-                    field.setAccessible(true);
-                    break;
-                }
-            }
-        }
-        return kilt$vsFluidPushRetField;
-    }
-
-    @Unique
-    private static Field kilt$getVsFluidAABBField() {
-        if (kilt$vsFluidAABBField == null) {
-            for (var field : Entity.class.getDeclaredFields()) {
-                if (field.getType() == AABB.class && field.getName().endsWith("valkyrienskies$fluidPushAABB")) {
-                    kilt$vsFluidAABBField = field;
-                    field.setAccessible(true);
-                    break;
-                }
-            }
-        }
-        return kilt$vsFluidAABBField;
-    }
+    @Dynamic("If this is not null we are running updateFluidHeightAndDoFluidPushing in the shipyard")
+    @Shadow(remap = false)
+    private AABB valkyrienskies$fluidPushAABB;
 
     @Unique
     private FluidType kilt$vsFluidType = null;
@@ -73,7 +40,7 @@ public class EntityMixin {
 
     // Not technically necessary, but gives us some protection in case some other mod does something weird.
     @Inject(method = "updateFluidHeightAndDoFluidPushing", at = @At("HEAD"))
-    private void resetOnStart(TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir) {
+    private void kilt$resetOnStart(TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir) {
         kilt$vsFluidType = null;
         kilt$vsInterimCalcs = null;
     }
@@ -82,79 +49,51 @@ public class EntityMixin {
     // we need to pass the fluid type from that one out.
     @Inject(
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;length()D", ordinal = 0),
-            method = "updateFluidHeightAndDoFluidPushing"
+            method = "updateFluidHeightAndDoFluidPushing",
+            order = 999
     )
     private void kilt$fixShipyardReturnValue(
             TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir,
-            @Share(value = "fluidType", namespace = KILT$ENTITY_INJECT) LocalRef<FluidType> fluidTypeRef,
-            @Share(value = "interimCalcs", namespace = KILT$ENTITY_INJECT) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs
+            @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef,
+            @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs
     ) {
-        try {
-            var valkFluidAABB = kilt$getVsFluidAABBField();
-            if (valkFluidAABB != null) {
-                var fluidAABB = (AABB) valkFluidAABB.get(this);
-                if (fluidAABB != null) {
-                    kilt$vsFluidType = fluidTypeRef.get();
-                    kilt$vsInterimCalcs = interimCalcs.get();
-                }
-            }
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+        if (valkyrienskies$fluidPushAABB != null) {
+            kilt$vsFluidType = fluidTypeRef.get();
+            kilt$vsInterimCalcs = interimCalcs.get();
         }
     }
 
+    @Dynamic("Implemented in EntityInject")
+    @Shadow
+    private boolean kilt$isCorrectFluidTypeForTag(
+            TagKey<Fluid> fluidTag, FluidType fluidType,
+            Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>> interimCalcs,
+            boolean defaultReturn
+    ) {
+        throw new AssertionError();
+    }
 
     // Valkyrien Skies uses cancellable instead of ModifyVariable, so this hack is necessary.
     // https://github.com/ValkyrienSkies/Valkyrien-Skies-2/blob/206b5c9eb1ebf25bdd23e998f66dc2957aa6dfc3/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/feature/water_in_ships_entity/MixinEntity.java#L179
     @Inject(
             method = "updateFluidHeightAndDoFluidPushing",
-            at = @At(value = "RETURN", ordinal = 1)
+            at = @At(value = "RETURN", ordinal = 1),
+            order = 999
     )
     private void kilt$fixVSReturnValue(
             TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir,
-            @Share(value = "fluidType", namespace = KILT$ENTITY_INJECT) LocalRef<FluidType> fluidTypeRef,
-            @Share(value = "interimCalcs", namespace = KILT$ENTITY_INJECT) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs
+            @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef,
+            @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs
     ) {
-        try {
-            var valkPushRet = kilt$getVSFluidPushRetField();
-            if (valkPushRet != null) {
-                var pushRet = (boolean) valkPushRet.get(this);
-                var correctPushRet = isCorrectFluidTag(
-                        fluidTag,
-                        kilt$vsFluidType != null ? kilt$vsFluidType : fluidTypeRef.get(),
-                        kilt$vsInterimCalcs != null ? kilt$vsInterimCalcs : interimCalcs.get(),
-                        pushRet
-                );
-                if (pushRet != correctPushRet) {
-                    valkPushRet.set(this, correctPushRet);
-                }
-            }
+        valkyrienskies$fluidPushRet = kilt$isCorrectFluidTypeForTag(
+                fluidTag,
+                kilt$vsFluidType != null ? kilt$vsFluidType : fluidTypeRef.get(),
+                kilt$vsInterimCalcs != null ? kilt$vsInterimCalcs : interimCalcs.get(),
+                valkyrienskies$fluidPushRet
+        );
 
-            kilt$vsFluidType = null;
-            kilt$vsInterimCalcs = null;
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Unique
-    private boolean isCorrectFluidTag(
-            TagKey<Fluid> fluidTag, FluidType fluidType,
-            Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>> interimCalcs,
-            boolean defaultReturn
-    ) {
-        if (fluidTag == FluidTags.WATER) {
-            if (fluidType != null && !fluidType.isAir())
-                return fluidType == ForgeMod.WATER_TYPE.get() || fluidType == PortingLibFluids.WATER_TYPE;
-            else if (interimCalcs != null)
-                return interimCalcs.containsKey(ForgeMod.WATER_TYPE.get());
-        } else if (fluidTag == FluidTags.LAVA) {
-            if (fluidType != null && !fluidType.isAir())
-                return fluidType == ForgeMod.LAVA_TYPE.get() || fluidType == PortingLibFluids.LAVA_TYPE;
-            else if (interimCalcs != null)
-                return interimCalcs.containsKey(ForgeMod.LAVA_TYPE.get());
-        }
-        return defaultReturn;
+        kilt$vsFluidType = null;
+        kilt$vsInterimCalcs = null;
     }
 
 }

--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/valkyrienskies/EntityMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/valkyrienskies/EntityMixin.java
@@ -1,0 +1,160 @@
+package xyz.bluspring.kilt.compat.fabric.mixin.valkyrienskies;
+
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
+import io.github.fabricators_of_create.porting_lib.fluids.PortingLibFluids;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.ForgeMod;
+import net.minecraftforge.fluids.FluidType;
+import org.apache.commons.lang3.tuple.MutableTriple;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.lang.reflect.Field;
+
+@IfModLoaded("valkyrienskies")
+@Mixin(value = Entity.class, priority = 999)
+public class EntityMixin {
+
+    @Unique
+    private static final String KILT$ENTITY_INJECT = "xyz.bluspring.kilt.forgeinjects.world.entity.EntityInject";
+
+    @Unique
+    private static Field kilt$vsFluidAABBField = null;
+
+    @Unique
+    private static Field kilt$vsFluidPushRetField = null;
+
+    // Field name is dynamically decorated by mixinextras.
+    // This was the best way I could think of to find it reliably.
+    @Unique
+    private static Field kilt$getVSFluidPushRetField() {
+        if (kilt$vsFluidPushRetField == null) {
+            for (var field : Entity.class.getDeclaredFields()) {
+                if (field.getType() == Boolean.TYPE && field.getName().endsWith("valkyrienskies$fluidPushRet")) {
+                    kilt$vsFluidPushRetField = field;
+                    field.setAccessible(true);
+                    break;
+                }
+            }
+        }
+        return kilt$vsFluidPushRetField;
+    }
+
+    @Unique
+    private static Field kilt$getVsFluidAABBField() {
+        if (kilt$vsFluidAABBField == null) {
+            for (var field : Entity.class.getDeclaredFields()) {
+                if (field.getType() == AABB.class && field.getName().endsWith("valkyrienskies$fluidPushAABB")) {
+                    kilt$vsFluidAABBField = field;
+                    field.setAccessible(true);
+                    break;
+                }
+            }
+        }
+        return kilt$vsFluidAABBField;
+    }
+
+    @Unique
+    private FluidType kilt$vsFluidType = null;
+
+    @Unique
+    private Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>> kilt$vsInterimCalcs = null;
+
+    // Not technically necessary, but gives us some protection in case some other mod does something weird.
+    @Inject(method = "updateFluidHeightAndDoFluidPushing", at = @At("HEAD"))
+    private void resetOnStart(TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir) {
+        kilt$vsFluidType = null;
+        kilt$vsInterimCalcs = null;
+    }
+
+    // VS calls updateFluidHeightAndDoFluidPushing recursively on the shipyard,
+    // we need to pass the fluid type from that one out.
+    @Inject(
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;length()D", ordinal = 0),
+            method = "updateFluidHeightAndDoFluidPushing"
+    )
+    private void kilt$fixShipyardReturnValue(
+            TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir,
+            @Share(value = "fluidType", namespace = KILT$ENTITY_INJECT) LocalRef<FluidType> fluidTypeRef,
+            @Share(value = "interimCalcs", namespace = KILT$ENTITY_INJECT) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs
+    ) {
+        try {
+            var valkFluidAABB = kilt$getVsFluidAABBField();
+            if (valkFluidAABB != null) {
+                var fluidAABB = (AABB) valkFluidAABB.get(this);
+                if (fluidAABB != null) {
+                    kilt$vsFluidType = fluidTypeRef.get();
+                    kilt$vsInterimCalcs = interimCalcs.get();
+                }
+            }
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    // Valkyrien Skies uses cancellable instead of ModifyVariable, so this hack is necessary.
+    // https://github.com/ValkyrienSkies/Valkyrien-Skies-2/blob/206b5c9eb1ebf25bdd23e998f66dc2957aa6dfc3/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/feature/water_in_ships_entity/MixinEntity.java#L179
+    @Inject(
+            method = "updateFluidHeightAndDoFluidPushing",
+            at = @At(value = "RETURN", ordinal = 1)
+    )
+    private void kilt$fixVSReturnValue(
+            TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir,
+            @Share(value = "fluidType", namespace = KILT$ENTITY_INJECT) LocalRef<FluidType> fluidTypeRef,
+            @Share(value = "interimCalcs", namespace = KILT$ENTITY_INJECT) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs
+    ) {
+        try {
+            var valkPushRet = kilt$getVSFluidPushRetField();
+            if (valkPushRet != null) {
+                var pushRet = (boolean) valkPushRet.get(this);
+                var correctPushRet = isCorrectFluidTag(
+                        fluidTag,
+                        kilt$vsFluidType != null ? kilt$vsFluidType : fluidTypeRef.get(),
+                        kilt$vsInterimCalcs != null ? kilt$vsInterimCalcs : interimCalcs.get(),
+                        pushRet
+                );
+                if (pushRet != correctPushRet) {
+                    valkPushRet.set(this, correctPushRet);
+                }
+            }
+
+            kilt$vsFluidType = null;
+            kilt$vsInterimCalcs = null;
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Unique
+    private boolean isCorrectFluidTag(
+            TagKey<Fluid> fluidTag, FluidType fluidType,
+            Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>> interimCalcs,
+            boolean defaultReturn
+    ) {
+        if (fluidTag == FluidTags.WATER) {
+            if (fluidType != null && !fluidType.isAir())
+                return fluidType == ForgeMod.WATER_TYPE.get() || fluidType == PortingLibFluids.WATER_TYPE;
+            else if (interimCalcs != null)
+                return interimCalcs.containsKey(ForgeMod.WATER_TYPE.get());
+        } else if (fluidTag == FluidTags.LAVA) {
+            if (fluidType != null && !fluidType.isAir())
+                return fluidType == ForgeMod.LAVA_TYPE.get() || fluidType == PortingLibFluids.LAVA_TYPE;
+            else if (interimCalcs != null)
+                return interimCalcs.containsKey(ForgeMod.LAVA_TYPE.get());
+        }
+        return defaultReturn;
+    }
+
+}

--- a/compat/fabric-compats/src/main/resources/kilt_fabric_compats.mixins.json
+++ b/compat/fabric-compats/src/main/resources/kilt_fabric_compats.mixins.json
@@ -46,6 +46,7 @@
         "sophisticatedcore.IForgeBlockStateMixin",
         "sophisticatedcore.IForgeItemMixin",
         "sophisticatedcore.IForgeItemStackMixin",
+        "valkyrienskies.EntityMixin",
         "wthit.WailaMixin"
     ],
     "client": [

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/EntityInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/EntityInject.java
@@ -24,9 +24,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.BlockParticleOption;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.Mth;
@@ -64,6 +62,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.bluspring.kilt.Kilt;
 import xyz.bluspring.kilt.helpers.mixin.Extends;
 import xyz.bluspring.kilt.injections.CapabilityProviderInjection;
 import xyz.bluspring.kilt.injections.world.entity.EntityInjection;
@@ -422,12 +421,12 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
     }
 
     @Inject(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos$MutableBlockPos;<init>()V", shift = At.Shift.AFTER))
-    private void kilt$initInterimCalcs(TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir, @Share("interimCalcs") LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs) {
+    private void kilt$initInterimCalcs(TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir, @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs) {
         interimCalcs.set(new Object2ObjectArrayMap<>(FluidType.SIZE.get() - 1));
     }
 
     @WrapOperation(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/material/FluidState;is(Lnet/minecraft/tags/TagKey;)Z", ordinal = 0))
-    private boolean kilt$checkIsValidFluidType(FluidState instance, TagKey<Fluid> tag, Operation<Boolean> original, @Share("fluidType") LocalRef<FluidType> fluidTypeRef) {
+    private boolean kilt$checkIsValidFluidType(FluidState instance, TagKey<Fluid> tag, Operation<Boolean> original, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef) {
         fluidTypeRef.set(instance.getFluidType());
 
         if (this.kilt$shouldUpdateFluid != null) {
@@ -438,7 +437,7 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
     }
 
     @WrapOperation(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "INVOKE", target = "Ljava/lang/Math;max(DD)D"))
-    private double kilt$useInterimCalc(double a, double b, Operation<Double> original, @Share("interimCalcs") LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs, @Share("fluidType") LocalRef<FluidType> fluidTypeRef, @Share("interim") LocalRef<MutableTriple<Double, Vec3, Integer>> interim) {
+    private double kilt$useInterimCalc(double a, double b, Operation<Double> original, @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef, @Share("interim") LocalRef<MutableTriple<Double, Vec3, Integer>> interim) {
         interim.set(interimCalcs.get().computeIfAbsent(fluidTypeRef.get(), t -> MutableTriple.of(0.0, Vec3.ZERO, 0)));
         interim.get().setLeft(Math.max(a, interim.get().getLeft()));
 
@@ -449,7 +448,7 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
     @Definition(id = "bl", local = @Local(type = boolean.class, ordinal = 0))
     @Expression("bl")
     @ModifyExpressionValue(method = "updateFluidHeightAndDoFluidPushing", at = @At("MIXINEXTRAS:EXPRESSION"))
-    private boolean kilt$checkIsPushedByFluid(boolean original, @Share("fluidType") LocalRef<FluidType> fluidTypeRef) {
+    private boolean kilt$checkIsPushedByFluid(boolean original, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef) {
         return this.isPushedByFluid(fluidTypeRef.get()) || original;
     }
 
@@ -464,7 +463,7 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
     }
 
     @Inject(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;length()D", ordinal = 0), cancellable = true)
-    private void kilt$useInterimValuesForCalc(TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir, @Share("interimCalcs") LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs) {
+    private void kilt$useInterimValuesForCalc(TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir, @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs) {
         if (interimCalcs.get().isEmpty() || (interimCalcs.get().size() == 1 && (interimCalcs.get().containsKey(ForgeMod.WATER_TYPE.get()) || interimCalcs.get().containsKey(ForgeMod.LAVA_TYPE.get())))) {
             interimCalcs.get().forEach((fluidType, interim) -> {
                 this.setFluidTypeHeight(fluidType, interim.getLeft());
@@ -507,40 +506,36 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
     }
 
     @WrapWithCondition(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "INVOKE", target = "Lit/unimi/dsi/fastutil/objects/Object2DoubleMap;put(Ljava/lang/Object;D)D", remap = false))
-    private boolean kilt$ensureIsActuallyInTag(Object2DoubleMap instance, Object o, double v, @Share("fluidType") LocalRef<FluidType> fluidTypeRef, @Share("interimCalcs") LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs, @Local(argsOnly = true) TagKey<Fluid> fluidTag) {
+    private boolean kilt$ensureIsActuallyInTag(Object2DoubleMap instance, Object o, double v, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef, @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs, @Local(argsOnly = true) TagKey<Fluid> fluidTag) {
         if (fluidTypeRef.get() == null && interimCalcs.get() == null)
             return true;
 
-        if (fluidTag == FluidTags.WATER) {
-            if (fluidTypeRef.get() != null && !fluidTypeRef.get().isAir())
-                return fluidTypeRef.get() == ForgeMod.WATER_TYPE.get() || fluidTypeRef.get() == PortingLibFluids.WATER_TYPE;
-            else if (interimCalcs.get() != null)
-                return interimCalcs.get().containsKey(ForgeMod.WATER_TYPE.get());
-        } else if (fluidTag == FluidTags.LAVA) {
-            if (fluidTypeRef.get() != null && !fluidTypeRef.get().isAir())
-                return fluidTypeRef.get() == ForgeMod.LAVA_TYPE.get() || fluidTypeRef.get() == PortingLibFluids.LAVA_TYPE;
-            else if (interimCalcs.get() != null)
-                return interimCalcs.get().containsKey(ForgeMod.LAVA_TYPE.get());
-        }
-
-        return true;
+        return kilt$isCorrectFluidTypeForTag(fluidTag, fluidTypeRef.get(), interimCalcs.get(), true);
     }
 
     @ModifyReturnValue(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "RETURN", ordinal = 1))
-    private boolean kilt$ensureIsActuallyInFluidType(boolean original, @Share("fluidType") LocalRef<FluidType> fluidTypeRef, @Share("interimCalcs") LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs, @Local(argsOnly = true) TagKey<Fluid> fluidTag) {
-        if (fluidTag == FluidTags.WATER) {
-            if (fluidTypeRef.get() != null && !fluidTypeRef.get().isAir())
-                return fluidTypeRef.get() == ForgeMod.WATER_TYPE.get() || fluidTypeRef.get() == PortingLibFluids.WATER_TYPE;
-            else if (interimCalcs.get() != null)
-                return interimCalcs.get().containsKey(ForgeMod.WATER_TYPE.get());
-        } else if (fluidTag == FluidTags.LAVA) {
-            if (fluidTypeRef.get() != null && !fluidTypeRef.get().isAir())
-                return fluidTypeRef.get() == ForgeMod.LAVA_TYPE.get() || fluidTypeRef.get() == PortingLibFluids.LAVA_TYPE;
-            else if (interimCalcs.get() != null)
-                return interimCalcs.get().containsKey(ForgeMod.LAVA_TYPE.get());
-        }
+    private boolean kilt$ensureIsActuallyInFluidType(boolean original, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef, @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs, @Local(argsOnly = true) TagKey<Fluid> fluidTag) {
+        return kilt$isCorrectFluidTypeForTag(fluidTag, fluidTypeRef.get(), interimCalcs.get(), original);
+    }
 
-        return original;
+    @Unique
+    private boolean kilt$isCorrectFluidTypeForTag(
+            TagKey<Fluid> fluidTag, FluidType fluidType,
+            Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>> interimCalcs,
+            boolean defaultReturn
+    ) {
+        if (fluidTag == FluidTags.WATER) {
+            if (fluidType != null && !fluidType.isAir())
+                return fluidType == ForgeMod.WATER_TYPE.get() || fluidType == PortingLibFluids.WATER_TYPE;
+            else if (interimCalcs != null)
+                return interimCalcs.containsKey(ForgeMod.WATER_TYPE.get());
+        } else if (fluidTag == FluidTags.LAVA) {
+            if (fluidType != null && !fluidType.isAir())
+                return fluidType == ForgeMod.LAVA_TYPE.get() || fluidType == PortingLibFluids.LAVA_TYPE;
+            else if (interimCalcs != null)
+                return interimCalcs.containsKey(ForgeMod.LAVA_TYPE.get());
+        }
+        return defaultReturn;
     }
 
     @Inject(method = "setPosRaw", at = @At("TAIL"))


### PR DESCRIPTION
I've discovered a major problem. Whenever Valkyrien Skies is installed, the game makes lava behave like water in various ways. One major side effect of this is that Striders die in lava.

This pull request resolves that. First off, [Valkyrien Skies uses cancellable instead of ModifyReturnValue](https://github.com/ValkyrienSkies/Valkyrien-Skies-2/blob/206b5c9eb1ebf25bdd23e998f66dc2957aa6dfc3/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/feature/water_in_ships_entity/MixinEntity.java#L179) to modify the output of Entity::updateFluidHeightAndDoFluidPushing, causing EntityInject::kilt$ensureIsActuallyInFluidType to miss it. I fixed this by modifying the field Valkyrien Skies returns in the cancellable inject.

However, there is another issue. It invokes Entity::updateFluidHeightAndDoFluidPushing recursively, which means solving the first problem will falsely make fluids in the shipyard return false. I solve this by passing the fluid type and interim calculations found in the shipyard to the calling function via some variables so they can be used instead.

One thing about this patch is that I use reflection to fetch some variables from the mixin manually, which might not be the most elegant way to do it. Let me know if there is a better way. Funnily enough I didn't actually need to include Valkyrien Skies as an explicit dependency in the gradle configuration because of this.