### PR TITLE
Sort the original mods list instead of having a separate sorted list only used during init.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -68,12 +68,6 @@ import kotlin.io.path.*
 class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
     private val tomlParser = TomlParser()
 
-    // I have no fucking clue why this is needed, but for whatever fucking reason,
-    // the mods ObjectArrayList is getting resorted *after* it's getting sorted in scanMods,
-    // no matter what the fuck I do.
-    // I don't have time to deal with this, so this works instead.
-    private lateinit var sortedModOrder: Collection<ForgeMod>
-
     private val environment = KiltEnvironment()
     var config = KiltLoaderConfig()
 
@@ -464,8 +458,10 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
         val graph = this.mods.buildGraph()
         val sorted = TopologicalSort.topologicalSort(graph, null)
 
-        // See comment at the lateinit
-        sortedModOrder = sorted
+        // Sort the mods, otherwise stuff breaks.
+        val modsRef = this.mods as MutableList<ForgeMod>
+        modsRef.clear()
+        modsRef.addAll(sorted)
 
         if (this.hasMod("embeddium")) {
             KnitLoader.instance.displayError("Kilt: You are using Embeddium, which is not supported under Kilt!", IllegalStateException())
@@ -556,7 +552,7 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
                 }
 
                 // TODO: Need to make sure to group mods together so they load in the correct order from each other
-                sortedModOrder.asFlow().concurrent()
+                mods.asFlow().concurrent()
                     .collect { mod ->
                         if (!mod.shouldScan) {
                             mod.scanData = ModFileScanData()
@@ -618,7 +614,7 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
         runBlocking {
             launch(Dispatchers.Default) {
                 // TODO: Need to make sure to group mods together so they load in the correct order from each other
-                sortedModOrder.asFlow().concurrent()
+                mods.asFlow().concurrent()
                     .collect { mod ->
                         try {
                             registerAnnotations(mod, mod.scanData)
@@ -732,7 +728,7 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
 
     private fun initMods(exception: Exception) {
         runBlocking {
-            sortedModOrder.asFlow()
+            mods.asFlow()
                 .collect { mod ->
                     try {
                         initMod(mod, mod.scanData)


### PR DESCRIPTION
Some mods like Deep Aether fail to load if `ModLoader::postEventWithWrapInModOrder` doesn't respect the mod dependency order.

I thought that there isn't really any reason to use the unsorted list anywhere else. Given that the code has changed so much since the issue that initially led to the creation of `sortedModOrder`, I think it should be safe to get rid of it and update the `mutableMods` list directly.