### PR TITLE
Fix crash with amecs 1.6 (amecsapi 1.8).

### DIFF
--- a/compat/fabric-compats/build.gradle.kts
+++ b/compat/fabric-compats/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
     modCompileOnly("de.siphalor:amecsapi-1.20:${property("amecsapi_version")}") {
         isTransitive = false
     }
+    modCompileOnly("de.siphalor.amecs.amecs-key-modifiers:amecs-key-modifiers-mc1.20.0:${property("amecs_key_modifiers_version")}") {
+        isTransitive = false
+    }
     modCompileOnly("dev.emi:emi-fabric:${property("emi_version")}")
     modCompileOnly("mezz.jei:jei-${property("minecraft_version")}-fabric:${property("jei_version")}")
     modCompileOnly("me.shedaniel:RoughlyEnoughItems-fabric:${property("rei_version")}")

--- a/compat/fabric-compats/gradle.properties
+++ b/compat/fabric-compats/gradle.properties
@@ -14,6 +14,7 @@ sophisticatedcore_version = 1.20.1-1.2.7.7.156
 creativecore_version = pcUy2Oig
 
 amecsapi_version = 1.5.3+mc1.20-pre1
+amecs_key_modifiers_version = 1.0.0
 
 # https://modrinth.com/mod/emi/versions?l=fabric&g=1.20.1
 emi_version = 1.1.22+1.20.1

--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecs_key_modifiers/AmecsKeyMappingManagerLayerMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecs_key_modifiers/AmecsKeyMappingManagerLayerMixin.java
@@ -1,0 +1,21 @@
+package xyz.bluspring.kilt.compat.fabric.mixin.amecs_key_modifiers;
+
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
+import de.siphalor.amecs.key_modifiers.api.AmecsKeyModifiersApi;
+import de.siphalor.amecs.key_modifiers.impl.AmecsKeyMappingManagerLayer;
+import de.siphalor.amecs.key_modifiers.impl.AmecsKeyModifiersModule;
+import net.minecraft.client.KeyMapping;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@IfModLoaded(value = "amecs_key_modifiers")
+@Mixin(AmecsKeyMappingManagerLayer.class)
+public abstract class AmecsKeyMappingManagerLayerMixin {
+    @Inject(method = "areExactModifiersPressed", at = @At("HEAD"), cancellable = true, require = 0)
+    private static void kilt$amecs_key_modifiers$disableIfNoModifiersAssigned(KeyMapping keyBinding, CallbackInfoReturnable<Boolean> cir) {
+        if (AmecsKeyModifiersApi.getBoundModifiers(keyBinding).isUnset() || AmecsKeyModifiersModule.CURRENT_MODIFIERS.isUnset())
+            cir.setReturnValue(false);
+    }
+}

--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecs_key_modifiers/AmecsKeyMappingManagerLayerMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecs_key_modifiers/AmecsKeyMappingManagerLayerMixin.java
@@ -6,10 +6,12 @@ import de.siphalor.amecs.key_modifiers.impl.AmecsKeyMappingManagerLayer;
 import de.siphalor.amecs.key_modifiers.impl.AmecsKeyModifiersModule;
 import net.minecraft.client.KeyMapping;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+@Pseudo
 @IfModLoaded(value = "amecs_key_modifiers")
 @Mixin(AmecsKeyMappingManagerLayer.class)
 public abstract class AmecsKeyMappingManagerLayerMixin {

--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecs_key_modifiers/KeyMappingMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecs_key_modifiers/KeyMappingMixin.java
@@ -8,11 +8,13 @@ import net.minecraft.client.KeyMapping;
 import net.minecraftforge.client.extensions.IForgeKeyMapping;
 import net.minecraftforge.client.settings.KeyModifier;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+@Pseudo
 @IfModLoaded("amecs_key_modifiers")
 @Mixin(value = KeyMapping.class, priority = 1010)
 public abstract class KeyMappingMixin {

--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecs_key_modifiers/KeyMappingMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecs_key_modifiers/KeyMappingMixin.java
@@ -1,12 +1,10 @@
-package xyz.bluspring.kilt.compat.fabric.mixin.amecsapi;
+package xyz.bluspring.kilt.compat.fabric.mixin.amecs_key_modifiers;
 
 import com.bawnorton.mixinsquared.TargetHandler;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.moulberry.mixinconstraints.annotations.IfModLoaded;
-import de.siphalor.amecs.api.KeyModifiers;
-import de.siphalor.amecs.impl.duck.IKeyBinding;
+import de.siphalor.amecs.key_modifiers.api.AmecsKeyModifierCombination;
 import net.minecraft.client.KeyMapping;
-import net.minecraft.network.chat.Component;
 import net.minecraftforge.client.extensions.IForgeKeyMapping;
 import net.minecraftforge.client.settings.KeyModifier;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,12 +13,12 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@IfModLoaded(value = "amecsapi", maxVersion = "1.7.0")
+@IfModLoaded("amecs_key_modifiers")
 @Mixin(value = KeyMapping.class, priority = 1010)
-public abstract class KeyMappingMixin implements IKeyBinding {
-    @TargetHandler(mixin = "de.siphalor.amecs.impl.mixin.MixinKeyBinding", name = "amecs$getKeyModifiers")
+public abstract class KeyMappingMixin {
+    @TargetHandler(mixin = "de.siphalor.amecs.key_modifiers.impl.mixin.MixinKeyMapping", name = "amecs$getBoundKeyModifiers")
     @Inject(method = "@MixinSquared:Handler", at = @At("RETURN"))
-    private void kilt$amecsapi$handleForgeModifiers(CallbackInfoReturnable<KeyModifiers> cir) {
+    private void kilt$amecs_key_modifiers$handleForgeModifiers(CallbackInfoReturnable<AmecsKeyModifierCombination> cir) {
         var keyModifiers = cir.getReturnValue();
 
         var forgeModifier = ((IForgeKeyMapping) this).getKeyModifier();
@@ -35,39 +33,39 @@ public abstract class KeyMappingMixin implements IKeyBinding {
         }
     }
 
-    @TargetHandler(mixin = "de.siphalor.amecs.impl.mixin.MixinKeyBinding", name = "getLocalizedName", prefix = "handler")
+    @TargetHandler(mixin = "de.siphalor.amecs.key_modifiers.impl.mixin.MixinKeyMapping", name = "getLocalizedName", prefix = "handler")
     @Inject(method = "@MixinSquared:Handler", at = @At("HEAD"), cancellable = true)
-    private void kilt$amecsapi$avoidHandlingLocalizedName(CallbackInfo ci) {
+    private void kilt$amecs_key_modifiers$avoidHandlingLocalizedName(CallbackInfo ci) {
         ci.cancel();
     }
 
-    @TargetHandler(mixin = "de.siphalor.amecs.impl.mixin.MixinKeyBinding", name = "onKeyPressed", prefix = "handler")
+    @TargetHandler(mixin = "de.siphalor.amecs.key_modifiers.impl.mixin.MixinKeyMapping", name = "onKeyPressed", prefix = "handler")
     @WrapWithCondition(method = "@MixinSquared:Handler", at = @At(value = "INVOKE", target = "Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;cancel()V"))
-    private static boolean kilt$amecsapi$avoidCallbackCancel(CallbackInfo instance) {
+    private static boolean kilt$amecs_key_modifiers$avoidCallbackCancel(CallbackInfo instance) {
         return false;
     }
 
-    @TargetHandler(mixin = "de.siphalor.amecs.impl.mixin.MixinKeyBinding", name = "setKeyPressed", prefix = "handler")
+    @TargetHandler(mixin = "de.siphalor.amecs.key_modifiers.impl.mixin.MixinKeyMapping", name = "setKeyPressed", prefix = "handler")
     @WrapWithCondition(method = "@MixinSquared:Handler", at = @At(value = "INVOKE", target = "Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;cancel()V"))
-    private static boolean kilt$amecsapi$avoidCallbackCancel2(CallbackInfo instance) {
+    private static boolean kilt$amecs_key_modifiers$avoidCallbackCancel2(CallbackInfo instance) {
         return false;
     }
 
-    @TargetHandler(mixin = "de.siphalor.amecs.impl.mixin.MixinKeyBinding", name = "updatePressedStates", prefix = "handler")
+    @TargetHandler(mixin = "de.siphalor.amecs.key_modifiers.impl.mixin.MixinKeyMapping", name = "updatePressedStates", prefix = "handler")
     @WrapWithCondition(method = "@MixinSquared:Handler", at = @At(value = "INVOKE", target = "Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;cancel()V"))
-    private static boolean kilt$amecsapi$avoidCallbackCancel3(CallbackInfo instance) {
+    private static boolean kilt$amecs_key_modifiers$avoidCallbackCancel3(CallbackInfo instance) {
         return false;
     }
 
-    @TargetHandler(mixin = "de.siphalor.amecs.impl.mixin.MixinKeyBinding", name = "updateKeysByCode", prefix = "handler")
+    @TargetHandler(mixin = "de.siphalor.amecs.key_modifiers.impl.mixin.MixinKeyMapping", name = "updateKeysByCode", prefix = "handler")
     @WrapWithCondition(method = "@MixinSquared:Handler", at = @At(value = "INVOKE", target = "Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;cancel()V"))
-    private static boolean kilt$amecsapi$avoidCallbackCancel4(CallbackInfo instance) {
+    private static boolean kilt$amecs_key_modifiers$avoidCallbackCancel4(CallbackInfo instance) {
         return false;
     }
 
-    @TargetHandler(mixin = "de.siphalor.amecs.impl.mixin.MixinKeyBinding", name = "unpressAll", prefix = "handler")
+    @TargetHandler(mixin = "de.siphalor.amecs.key_modifiers.impl.mixin.MixinKeyMapping", name = "unpressAll", prefix = "handler")
     @WrapWithCondition(method = "@MixinSquared:Handler", at = @At(value = "INVOKE", target = "Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;cancel()V"))
-    private static boolean kilt$amecsapi$avoidCallbackCancel5(CallbackInfo instance) {
+    private static boolean kilt$amecs_key_modifiers$avoidCallbackCancel5(CallbackInfo instance) {
         return false;
     }
 }

--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecsapi/KeyBindingManagerMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecsapi/KeyBindingManagerMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.stream.Stream;
 
-@IfModLoaded("amecsapi")
+@IfModLoaded(value = "amecsapi", maxVersion = "1.7.0")
 @Mixin(KeyBindingManager.class)
 public abstract class KeyBindingManagerMixin {
     @IfModLoaded(value = "amecsapi", minVersion = "1.5.3")

--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecsapi/KeyBindingManagerMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecsapi/KeyBindingManagerMixin.java
@@ -7,12 +7,14 @@ import de.siphalor.amecs.impl.AmecsAPI;
 import de.siphalor.amecs.impl.KeyBindingManager;
 import net.minecraft.client.KeyMapping;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.stream.Stream;
 
+@Pseudo
 @IfModLoaded(value = "amecsapi", maxVersion = "1.7.0")
 @Mixin(KeyBindingManager.class)
 public abstract class KeyBindingManagerMixin {

--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecsapi/KeyMappingMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/amecsapi/KeyMappingMixin.java
@@ -10,11 +10,13 @@ import net.minecraft.network.chat.Component;
 import net.minecraftforge.client.extensions.IForgeKeyMapping;
 import net.minecraftforge.client.settings.KeyModifier;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+@Pseudo
 @IfModLoaded(value = "amecsapi", maxVersion = "1.7.0")
 @Mixin(value = KeyMapping.class, priority = 1010)
 public abstract class KeyMappingMixin implements IKeyBinding {

--- a/compat/fabric-compats/src/main/resources/kilt_fabric_compats.mixins.json
+++ b/compat/fabric-compats/src/main/resources/kilt_fabric_compats.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "accessories.DataLoaderBaseMixin",
+    "amecs_key_modifiers.AmecsKeyMappingManagerLayerMixin",
     "architectury.RegistrarManagerImplMixin",
     "creativecore.CreativeNetworkMixin",
     "emi.EmiAgnosFabricMixin",
@@ -53,6 +54,7 @@
     "wthit.WailaMixin"
   ],
   "client": [
+    "amecs_key_modifiers.KeyMappingMixin",
     "amecsapi.KeyBindingManagerMixin",
     "amecsapi.KeyMappingMixin",
     "mkb.KeyMappingMixin"


### PR DESCRIPTION
The latest version of amecs splits different parts of the codebase into separate modules.
This means that the class paths and class names are different, which means that Kilt's compatibility mixins no longer work.

Luckily, the underlying code is essentially the same, making this an easy fix.
That said, to maintain backwards compatibility I decided to just make a copy of the old code.

Also worth mentioning that KeyBindingManager is now split into AmecsKeyMappingManager and AmecsKeyMappingManagerLayer. KeyBindingManager was client-only before, but now only AmecsKeyMappingManager is client-only. AmecsKeyMappingManagerLayer is common, so I made the mixin common as well. Do you think I should mark the mixin as client-only?