### PR TITLE
Fix crash with registrate forge.

### DIFF
--- a/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/AbstractRegistrateInjectionMixin.java
+++ b/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/AbstractRegistrateInjectionMixin.java
@@ -1,8 +1,10 @@
 package xyz.bluspring.kilt.compat.create.mixin.registrate_fabric;
 
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
 import org.spongepowered.asm.mixin.Mixin;
 import xyz.bluspring.kilt.compat.create.registrate.injects.AbstractRegistrateInjection;
 
+@IfModLoaded("registrate-fabric")
 @Mixin(AbstractRegistrateInjection.class) // Only here to force the token replacement to occur!
 public interface AbstractRegistrateInjectionMixin {
 }

--- a/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidBuilderHelperMixin.java
+++ b/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidBuilderHelperMixin.java
@@ -1,8 +1,10 @@
 package xyz.bluspring.kilt.compat.create.mixin.registrate_fabric;
 
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
 import org.spongepowered.asm.mixin.Mixin;
 import xyz.bluspring.kilt.compat.create.registrate.FluidBuilderHelper;
 
+@IfModLoaded("registrate-fabric")
 @Mixin(FluidBuilderHelper.class) // Only here to force the token replacement to occur!
 public abstract class FluidBuilderHelperMixin {
 }

--- a/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidEntryMixin.java
+++ b/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidEntryMixin.java
@@ -1,5 +1,6 @@
 package xyz.bluspring.kilt.compat.create.mixin.registrate_fabric;
 
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.fabric.RegistryObject;
 import com.tterrag.registrate.util.entry.FluidEntry;
@@ -8,6 +9,7 @@ import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidType;
 import org.spongepowered.asm.mixin.Mixin;
 
+@IfModLoaded("registrate-fabric")
 @SuppressWarnings("rawtypes")
 @Mixin(FluidEntry.class)
 public abstract class FluidEntryMixin extends RegistryEntry {

--- a/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/RegistrateBlockstateProviderMixin.java
+++ b/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/RegistrateBlockstateProviderMixin.java
@@ -1,5 +1,6 @@
 package xyz.bluspring.kilt.compat.create.mixin.registrate_fabric;
 
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.providers.RegistrateBlockstateProvider;
 import net.minecraft.data.PackOutput;
@@ -13,6 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.bluspring.kilt.helpers.mixin.CreateInitializer;
 import xyz.bluspring.kilt.workarounds.datagen.WorkaroundBlockStateProvider;
 
+@IfModLoaded("registrate-fabric")
 @Mixin(RegistrateBlockstateProvider.class)
 public abstract class RegistrateBlockstateProviderMixin {
     private BlockStateProvider kilt$forgeProvider;

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltInsnConflictRemapProvider.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltInsnConflictRemapProvider.kt
@@ -35,16 +35,18 @@ class KiltInsnConflictRemapProvider : InsnConflictRemapProvider {
                 }
         }
 
-        when (owner) {
-            "com/tterrag/registrate/builders/FluidBuilder" ->
-                when (name) {
-                    "create" -> return $$"kilt$create"
-                }
+        if (FabricLoader.getInstance().isModLoaded("registrate-fabric")) {
+            when (owner) {
+                "com/tterrag/registrate/builders/FluidBuilder" ->
+                    when (name) {
+                        "create" -> return $$"kilt$create"
+                    }
 
-            "com/tterrag/registrate/AbstractRegistrate" ->
-                when (name) {
-                    "fluid" -> return $$"kilt$fluid"
-                }
+                "com/tterrag/registrate/AbstractRegistrate" ->
+                    when (name) {
+                        "fluid" -> return $$"kilt$fluid"
+                    }
+            }
         }
 
         return super.remapMethod(owner, name, descriptor)


### PR DESCRIPTION
Adds a few missing `@IfModLoaded`-statements.
Also skip remapping registrate methods when using registrate forge, to allow mods like GregTech Forge and Create Forge to work without installing Registrate Fabric.