### PR TITLE
Allow KiltMixinModifications to use Mojang mappings instead of SRG.

### DIFF
--- a/src/main/kotlin/net/minecraftforge/coremod/api/ASMAPI.kt
+++ b/src/main/kotlin/net/minecraftforge/coremod/api/ASMAPI.kt
@@ -46,7 +46,7 @@ object ASMAPI {
         methodDescriptor: String,
         type: MethodType
     ): MethodInsnNode {
-        return MethodInsnNode(type.toOpcode(), KiltRemapper.remapClass(ownerName), KiltRemapper.enhancedRemapper.mapMethodName(ownerName, methodName, methodDescriptor), KiltRemapper.remapDescriptor(methodDescriptor), type == MethodType.INTERFACE)
+        return MethodInsnNode(type.toOpcode(), KiltRemapper.remapClass(ownerName), KiltRemapper.enhancedSRGRemapper.mapMethodName(ownerName, methodName, methodDescriptor), KiltRemapper.remapDescriptor(methodDescriptor), type == MethodType.INTERFACE)
     }
 
     @JvmStatic

--- a/src/main/kotlin/net/minecraftforge/coremod/api/ASMAPI.kt
+++ b/src/main/kotlin/net/minecraftforge/coremod/api/ASMAPI.kt
@@ -46,7 +46,7 @@ object ASMAPI {
         methodDescriptor: String,
         type: MethodType
     ): MethodInsnNode {
-        return MethodInsnNode(type.toOpcode(), KiltRemapper.remapClass(ownerName), KiltRemapper.enhancedSRGRemapper.mapMethodName(ownerName, methodName, methodDescriptor), KiltRemapper.remapDescriptor(methodDescriptor), type == MethodType.INTERFACE)
+        return MethodInsnNode(type.toOpcode(), KiltRemapper.remapClass(ownerName), KiltRemapper.enhancedSrgRemapper.mapMethodName(ownerName, methodName, methodDescriptor), KiltRemapper.remapDescriptor(methodDescriptor), type == MethodType.INTERFACE)
     }
 
     @JvmStatic

--- a/src/main/kotlin/net/minecraftforge/fml/util/ObfuscationReflectionHelper.kt
+++ b/src/main/kotlin/net/minecraftforge/fml/util/ObfuscationReflectionHelper.kt
@@ -23,7 +23,7 @@ object ObfuscationReflectionHelper {
     fun remapName(domain: INameMappingService.Domain, name: String): String {
         return when (domain) {
             INameMappingService.Domain.CLASS -> {
-                fabricRemapper.mapClassName("intermediary", KiltRemapper.enhancedSRGRemapper.map(name))
+                fabricRemapper.mapClassName("intermediary", KiltRemapper.enhancedSrgRemapper.map(name))
             }
 
             INameMappingService.Domain.FIELD -> {
@@ -68,7 +68,7 @@ object ObfuscationReflectionHelper {
             val methodName = if (KiltRemapper.srgMappedMethods.containsKey(methodName)) {
                 val descriptor = Type.getMethodDescriptor(Type.VOID_TYPE, *parameterTypes.map { Type.getType(it) }.toTypedArray()).removeSuffix("V")
 
-                val mapped = KiltRemapper.enhancedSRGRemapper.mapMethodNamePrefixDesc(clazz.typeName.replace(".", "/"), methodName, descriptor)
+                val mapped = KiltRemapper.enhancedSrgRemapper.mapMethodNamePrefixDesc(clazz.typeName.replace(".", "/"), methodName, descriptor)
 
                 if ((mapped == methodName || mapped == null) && (methodName.startsWith("m_") || methodName.startsWith("f_")) && methodName.endsWith("_"))
                     KiltRemapper.srgMappedMethods[methodName]!!.values.first()

--- a/src/main/kotlin/net/minecraftforge/fml/util/ObfuscationReflectionHelper.kt
+++ b/src/main/kotlin/net/minecraftforge/fml/util/ObfuscationReflectionHelper.kt
@@ -23,7 +23,7 @@ object ObfuscationReflectionHelper {
     fun remapName(domain: INameMappingService.Domain, name: String): String {
         return when (domain) {
             INameMappingService.Domain.CLASS -> {
-                fabricRemapper.mapClassName("intermediary", KiltRemapper.enhancedRemapper.map(name))
+                fabricRemapper.mapClassName("intermediary", KiltRemapper.enhancedSRGRemapper.map(name))
             }
 
             INameMappingService.Domain.FIELD -> {
@@ -68,7 +68,7 @@ object ObfuscationReflectionHelper {
             val methodName = if (KiltRemapper.srgMappedMethods.containsKey(methodName)) {
                 val descriptor = Type.getMethodDescriptor(Type.VOID_TYPE, *parameterTypes.map { Type.getType(it) }.toTypedArray()).removeSuffix("V")
 
-                val mapped = KiltRemapper.enhancedRemapper.mapMethodNamePrefixDesc(clazz.typeName.replace(".", "/"), methodName, descriptor)
+                val mapped = KiltRemapper.enhancedSRGRemapper.mapMethodNamePrefixDesc(clazz.typeName.replace(".", "/"), methodName, descriptor)
 
                 if ((mapped == methodName || mapped == null) && (methodName.startsWith("m_") || methodName.startsWith("f_")) && methodName.endsWith("_"))
                     KiltRemapper.srgMappedMethods[methodName]!!.values.first()

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/AccessTransformerLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/AccessTransformerLoader.kt
@@ -307,7 +307,7 @@ object AccessTransformerLoader {
 
     private fun widenAccessForVanillaClasses(split: List<String>, srgClassName: String, classTweaker: ClassTweaker): Boolean {
         val intermediaryClassName = KiltRemapper.remapClass(srgClassName)
-        val remapper = KiltRemapper.enhancedRemapper
+        val remapper = KiltRemapper.enhancedSRGRemapper
         val accessWidener = classTweaker.visitAccessWidener(intermediaryClassName)!! // it shouldn't be possible for this to be null.
 
         // field / method
@@ -392,7 +392,7 @@ object AccessTransformerLoader {
                 val name = split[2]
 
                 val fieldInfo = KiltRemapper.srgIntermediaryMapping.getClass(srgClassName)?.fields?.firstOrNull { it.original == name } ?: return false
-                val fieldName = KiltRemapper.enhancedRemapper.mapFieldName(srgClassName.replace(".", "/"), name, fieldInfo.descriptor ?: return false)
+                val fieldName = KiltRemapper.enhancedSRGRemapper.mapFieldName(srgClassName.replace(".", "/"), name, fieldInfo.descriptor ?: return false)
 
                 accessWidener.visitField(fieldName, KiltRemapper.remapDescriptor(fieldInfo.descriptor!!), AccessWidenerVisitor.AccessType.ACCESSIBLE, true)
                 accessWidener.visitField(fieldName, KiltRemapper.remapDescriptor(fieldInfo.descriptor!!), AccessWidenerVisitor.AccessType.MUTABLE, true)

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/AccessTransformerLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/AccessTransformerLoader.kt
@@ -307,7 +307,7 @@ object AccessTransformerLoader {
 
     private fun widenAccessForVanillaClasses(split: List<String>, srgClassName: String, classTweaker: ClassTweaker): Boolean {
         val intermediaryClassName = KiltRemapper.remapClass(srgClassName)
-        val remapper = KiltRemapper.enhancedSRGRemapper
+        val remapper = KiltRemapper.enhancedSrgRemapper
         val accessWidener = classTweaker.visitAccessWidener(intermediaryClassName)!! // it shouldn't be possible for this to be null.
 
         // field / method
@@ -392,7 +392,7 @@ object AccessTransformerLoader {
                 val name = split[2]
 
                 val fieldInfo = KiltRemapper.srgIntermediaryMapping.getClass(srgClassName)?.fields?.firstOrNull { it.original == name } ?: return false
-                val fieldName = KiltRemapper.enhancedSRGRemapper.mapFieldName(srgClassName.replace(".", "/"), name, fieldInfo.descriptor ?: return false)
+                val fieldName = KiltRemapper.enhancedSrgRemapper.mapFieldName(srgClassName.replace(".", "/"), name, fieldInfo.descriptor ?: return false)
 
                 accessWidener.visitField(fieldName, KiltRemapper.remapDescriptor(fieldInfo.descriptor!!), AccessWidenerVisitor.AccessType.ACCESSIBLE, true)
                 accessWidener.visitField(fieldName, KiltRemapper.remapDescriptor(fieldInfo.descriptor!!), AccessWidenerVisitor.AccessType.MUTABLE, true)

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/coremod/CoreMod.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/coremod/CoreMod.kt
@@ -97,7 +97,7 @@ class CoreMod(val mod: ForgeMod, val id: String, val file: String) {
                     val methodName = targetData["methodName"] as String
                     val descName = targetData["methodDesc"] as String
 
-                    val mappedMethodName = KiltRemapper.enhancedRemapper.mapMethodName(className, methodName, descName)
+                    val mappedMethodName = KiltRemapper.enhancedSRGRemapper.mapMethodName(className, methodName, descName)
                     val mappedDescName = KiltRemapper.remapDescriptor(descName)
 
                     logger.debug("Binding $name: Added method $methodName$mappedDescName / $mappedMethodName$mappedDescName from class $className as target")

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/coremod/CoreMod.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/coremod/CoreMod.kt
@@ -97,7 +97,7 @@ class CoreMod(val mod: ForgeMod, val id: String, val file: String) {
                     val methodName = targetData["methodName"] as String
                     val descName = targetData["methodDesc"] as String
 
-                    val mappedMethodName = KiltRemapper.enhancedSRGRemapper.mapMethodName(className, methodName, descName)
+                    val mappedMethodName = KiltRemapper.enhancedSrgRemapper.mapMethodName(className, methodName, descName)
                     val mappedDescName = KiltRemapper.remapDescriptor(descName)
 
                     logger.debug("Binding $name: Added method $methodName$mappedDescName / $mappedMethodName$mappedDescName from class $className as target")

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
@@ -670,4 +670,8 @@ object KiltMixinModifications {
         ACCESSORS[typeDesc] = list
         return list
     }
+
+    init {
+        KiltRemapper.discardMojangMappings()
+    }
 }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
@@ -22,6 +22,7 @@ import xyz.bluspring.kilt.loader.mixin.modifications.modifiers.AnnotationBasedMo
 import xyz.bluspring.kilt.loader.mixin.modifications.modifiers.InjectedShareAccessModifier
 import xyz.bluspring.kilt.loader.mixin.modifications.modifiers.MethodBasedModifier
 import xyz.bluspring.kilt.loader.mixin.modifications.modifiers.MixinModifier
+import xyz.bluspring.kilt.loader.remap.KiltEnhancedRemapper
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import xyz.bluspring.kilt.loader.remap.fixers.mixin.MixinRemapper
 
@@ -644,6 +645,20 @@ object KiltMixinModifications {
                 modifier.mappedMethods = modifier.methods.map {
                     remapMethod(it, modifier.owner)
                 }
+            }
+            if (modifier is NameRemappingAnnotationModifier) {
+                modifier.remapMethodsTo = MixinRemapper.remapTargetString(
+                    modifier.remapMethodsTo, listOf(KiltRemapper.unmapClass(modifier.owner)),
+                    KiltRemapper.enhancedMojangRemapper as KiltEnhancedRemapper
+                )
+            }
+            if (modifier is ReplacedAnnotationsModifier) {
+                val mutableList = modifier.replaceWith.toMutableList()
+                MixinRemapper.remapMixinAnnotations(
+                    mutableList, KiltRemapper.enhancedMojangRemapper as KiltEnhancedRemapper,
+                    listOf(modifier.owner), modifier.owner
+                )
+                modifier.replaceWith = mutableList
             }
 
             list.add(modifier)

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
@@ -617,6 +617,20 @@ object KiltMixinModifications {
         })
     }
 
+    fun remapMethod(method: String, owner: String): String {
+        return if (method.contains("(")) {
+            val name = method.replaceAfter("(", "").removeSuffix("(")
+            val descriptor = method.removePrefix(name)
+            val mappedDesc = KiltRemapper.remapDescriptor(descriptor)
+
+            if (KiltRemapper.srgMappedMethods.contains(name)) {
+                "${KiltRemapper.srgMappedMethods[name]?.get(owner) ?: name}$mappedDesc"
+            } else {
+                "${KiltRemapper.mojangMappedMethods[name]?.get(owner) ?: name}$mappedDesc"
+            }
+        } else method
+    }
+
     fun register(type: Class<*>, vararg mixinModifiers: MixinModifier): List<MixinModifier> {
         val list = mutableListOf<MixinModifier>()
         val typeDesc = Type.getDescriptor(type)
@@ -628,13 +642,7 @@ object KiltMixinModifications {
 
             if (modifier is MethodBasedModifier) {
                 modifier.mappedMethods = modifier.methods.map {
-                    (if (it.contains("(")) {
-                        val name = it.replaceAfter("(", "").removeSuffix("(")
-                        val descriptor = it.removePrefix(name)
-                        val mappedDesc = KiltRemapper.remapDescriptor(descriptor)
-
-                        "${KiltRemapper.srgMappedMethods[name]?.get(modifier.owner) ?: name}$mappedDesc"
-                    } else it)
+                    remapMethod(it, modifier.owner)
                 }
             }
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/AnnotationBasedModifier.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/AnnotationBasedModifier.kt
@@ -3,6 +3,7 @@ package xyz.bluspring.kilt.loader.mixin.modifications.modifiers
 import org.objectweb.asm.tree.AnnotationNode
 import org.spongepowered.asm.mixin.transformer.ClassInfo
 import xyz.bluspring.kilt.loader.mixin.modifications.KiltMixinModifications
+import xyz.bluspring.kilt.loader.remap.KiltEnhancedRemapper
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import xyz.bluspring.kilt.loader.remap.fixers.mixin.MixinRemapper
 
@@ -47,8 +48,9 @@ sealed interface AnnotationBasedModifier : MethodBasedModifier {
             } else {
                 annotationsToAdd.addAll(this.replaceWith)
             }
+            if (KiltRemapper.enhancedMojangRemapper == null) throw IllegalStateException("Enhanced Mojang remapper was discarded too soon!")
             MixinRemapper.remapMixinAnnotations(
-                annotationsToAdd, KiltRemapper.enhancedMojangRemapper,
+                annotationsToAdd, KiltRemapper.enhancedMojangRemapper as KiltEnhancedRemapper,
                 listOf(owner), classInfo.name
             )
             newAnnotations.addAll(annotationsToAdd)
@@ -69,10 +71,14 @@ sealed interface AnnotationBasedModifier : MethodBasedModifier {
             val newAnnotation = run {
                 val annotation = KiltMixinModifications.getBaseAnnotation(annotation)
 
+                if (KiltRemapper.enhancedMojangRemapper == null) throw IllegalStateException("Enhanced Mojang remapper was discarded too soon!")
                 KiltMixinModifications.createAnnotation(annotation.desc,
                     KiltMixinModifications.annotationValuesToMap(annotation.values).toMutableMap().apply {
                         this["method"] = listOf(
-                            MixinRemapper.remapTargetString(remapMethodsTo, listOf(KiltRemapper.unmapClass(classInfo.name)), KiltRemapper.enhancedMojangRemapper)
+                            MixinRemapper.remapTargetString(
+                                remapMethodsTo, listOf(KiltRemapper.unmapClass(classInfo.name)),
+                                KiltRemapper.enhancedMojangRemapper as KiltEnhancedRemapper
+                            )
                         )
                     })
             }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/AnnotationBasedModifier.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/AnnotationBasedModifier.kt
@@ -23,7 +23,6 @@ sealed interface AnnotationBasedModifier : MethodBasedModifier {
         override lateinit var mappedMethods: List<String>
 
         override fun modifyMixin(classInfo: ClassInfo, annotation: AnnotationNode, newAnnotations: MutableList<AnnotationNode>) {
-            val annotationsToAdd: MutableList<AnnotationNode> = mutableListOf()
             if (annotation.desc == KiltMixinModifications.SUGAR_WRAPPER.descriptor) {
                 val list = this.replaceWith
 
@@ -31,29 +30,23 @@ sealed interface AnnotationBasedModifier : MethodBasedModifier {
                     val map = KiltMixinModifications.annotationValuesToMap(annotation.values).toMutableMap()
                     map["original"] = list[0]
                     annotation.values = KiltMixinModifications.mapToAnnotationValues(map)
-                    annotationsToAdd.add(annotation)
+                    newAnnotations.add(annotation)
                 } else {
                     val map = KiltMixinModifications.annotationValuesToMap(annotation.values).toMutableMap()
 
                     for (node in list) {
                         if (node.desc.contains("mixinsquared"))
-                            annotationsToAdd.add(node)
+                            newAnnotations.add(node)
                         else
                             map["original"] = node
                     }
 
                     annotation.values = KiltMixinModifications.mapToAnnotationValues(map)
-                    annotationsToAdd.add(annotation)
+                    newAnnotations.add(annotation)
                 }
             } else {
-                annotationsToAdd.addAll(this.replaceWith)
+                newAnnotations.addAll(this.replaceWith)
             }
-            if (KiltRemapper.enhancedMojangRemapper == null) throw IllegalStateException("Enhanced Mojang remapper was discarded too soon!")
-            MixinRemapper.remapMixinAnnotations(
-                annotationsToAdd, KiltRemapper.enhancedMojangRemapper as KiltEnhancedRemapper,
-                listOf(owner), classInfo.name
-            )
-            newAnnotations.addAll(annotationsToAdd)
         }
     }
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/AnnotationBasedModifier.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/AnnotationBasedModifier.kt
@@ -3,9 +3,6 @@ package xyz.bluspring.kilt.loader.mixin.modifications.modifiers
 import org.objectweb.asm.tree.AnnotationNode
 import org.spongepowered.asm.mixin.transformer.ClassInfo
 import xyz.bluspring.kilt.loader.mixin.modifications.KiltMixinModifications
-import xyz.bluspring.kilt.loader.remap.KiltEnhancedRemapper
-import xyz.bluspring.kilt.loader.remap.KiltRemapper
-import xyz.bluspring.kilt.loader.remap.fixers.mixin.MixinRemapper
 
 sealed interface AnnotationBasedModifier : MethodBasedModifier {
     val variables: Map<String, Any>
@@ -17,7 +14,7 @@ sealed interface AnnotationBasedModifier : MethodBasedModifier {
         override val methods: List<String> = listOf(),
         override val variables: Map<String, Any> = mapOf(),
 
-        val replaceWith: List<AnnotationNode> = listOf()
+        var replaceWith: List<AnnotationNode> = listOf()
     ) : AnnotationBasedModifier {
         override lateinit var mappedOwner: String
         override lateinit var mappedMethods: List<String>
@@ -55,7 +52,7 @@ sealed interface AnnotationBasedModifier : MethodBasedModifier {
         override val methods: List<String> = listOf(),
         override val variables: Map<String, Any> = mapOf(),
 
-        val remapMethodsTo: String,
+        var remapMethodsTo: String,
     ) : AnnotationBasedModifier {
         override lateinit var mappedOwner: String
         override lateinit var mappedMethods: List<String>
@@ -64,15 +61,9 @@ sealed interface AnnotationBasedModifier : MethodBasedModifier {
             val newAnnotation = run {
                 val annotation = KiltMixinModifications.getBaseAnnotation(annotation)
 
-                if (KiltRemapper.enhancedMojangRemapper == null) throw IllegalStateException("Enhanced Mojang remapper was discarded too soon!")
                 KiltMixinModifications.createAnnotation(annotation.desc,
                     KiltMixinModifications.annotationValuesToMap(annotation.values).toMutableMap().apply {
-                        this["method"] = listOf(
-                            MixinRemapper.remapTargetString(
-                                remapMethodsTo, listOf(KiltRemapper.unmapClass(classInfo.name)),
-                                KiltRemapper.enhancedMojangRemapper as KiltEnhancedRemapper
-                            )
-                        )
+                        this["method"] = listOf(remapMethodsTo)
                     })
             }
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/AnnotationBasedModifier.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/AnnotationBasedModifier.kt
@@ -66,7 +66,7 @@ sealed interface AnnotationBasedModifier : MethodBasedModifier {
                 KiltMixinModifications.createAnnotation(annotation.desc,
                     KiltMixinModifications.annotationValuesToMap(annotation.values).toMutableMap().apply {
                         this["method"] = listOf(
-                            MixinRemapper.remapTargetString(remapMethodsTo, listOf(KiltRemapper.unmapClass(classInfo.name)), KiltRemapper.enhancedRemapper)
+                            MixinRemapper.remapTargetString(remapMethodsTo, listOf(KiltRemapper.unmapClass(classInfo.name)), KiltRemapper.enhancedMojangRemapper)
                         )
                     })
             }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/AnnotationBasedModifier.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/AnnotationBasedModifier.kt
@@ -22,6 +22,7 @@ sealed interface AnnotationBasedModifier : MethodBasedModifier {
         override lateinit var mappedMethods: List<String>
 
         override fun modifyMixin(classInfo: ClassInfo, annotation: AnnotationNode, newAnnotations: MutableList<AnnotationNode>) {
+            val annotationsToAdd: MutableList<AnnotationNode> = mutableListOf()
             if (annotation.desc == KiltMixinModifications.SUGAR_WRAPPER.descriptor) {
                 val list = this.replaceWith
 
@@ -29,23 +30,28 @@ sealed interface AnnotationBasedModifier : MethodBasedModifier {
                     val map = KiltMixinModifications.annotationValuesToMap(annotation.values).toMutableMap()
                     map["original"] = list[0]
                     annotation.values = KiltMixinModifications.mapToAnnotationValues(map)
-                    newAnnotations.add(annotation)
+                    annotationsToAdd.add(annotation)
                 } else {
                     val map = KiltMixinModifications.annotationValuesToMap(annotation.values).toMutableMap()
 
                     for (node in list) {
                         if (node.desc.contains("mixinsquared"))
-                            newAnnotations.add(node)
+                            annotationsToAdd.add(node)
                         else
                             map["original"] = node
                     }
 
                     annotation.values = KiltMixinModifications.mapToAnnotationValues(map)
-                    newAnnotations.add(annotation)
+                    annotationsToAdd.add(annotation)
                 }
             } else {
-                newAnnotations.addAll(this.replaceWith)
+                annotationsToAdd.addAll(this.replaceWith)
             }
+            MixinRemapper.remapMixinAnnotations(
+                annotationsToAdd, KiltRemapper.enhancedMojangRemapper,
+                listOf(owner), classInfo.name
+            )
+            newAnnotations.addAll(annotationsToAdd)
         }
     }
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
@@ -96,7 +96,7 @@ object KiltRemapper {
     // srg -> intermediary
     val srgIntermediaryMapping: IMappingFile = mappingFile.getMap("searge", "intermediary")
     // mojang -> intermediary
-    val intermediaryMojMapping: IMappingFile = mappingFile.getMap("intermediary", "mojang").reverse()
+    val mojIntermediaryMapping: IMappingFile = mappingFile.getMap("intermediary", "mojang").reverse()
 
     val fabricMappings: INamedMappingFile = MappingConfiguration::class.java.classLoader.getResourceAsStream("mappings/mappings.tiny")!!.use { INamedMappingFile.load(it) }
 
@@ -107,7 +107,7 @@ object KiltRemapper {
             this
     }
 
-    private val devMojangIntermediaryMapping = intermediaryMojMapping.run {
+    private val devMojangIntermediaryMapping = mojIntermediaryMapping.run {
         if (!forceProductionRemap)
             this.rename(DevMappingRenamer(FabricLoader.getInstance().mappingResolver))
         else
@@ -127,7 +127,7 @@ object KiltRemapper {
         this::class.java.getResourceAsStream("/kilt_workaround_mappings.tiny")!!.bufferedReader()
     )
 
-    lateinit var enhancedSRGRemapper: KiltEnhancedRemapper
+    lateinit var enhancedSrgRemapper: KiltEnhancedRemapper
     lateinit var enhancedMojangRemapper: KiltEnhancedRemapper
 
     private lateinit var remappedModsDir: Path
@@ -351,7 +351,7 @@ object KiltRemapper {
         else null
 
         // Initialize a global remapper state
-        enhancedSRGRemapper = KiltEnhancedRemapper(srgClassProvider, devSrgIntermediaryMapping, logConsumer) {
+        enhancedSrgRemapper = KiltEnhancedRemapper(srgClassProvider, devSrgIntermediaryMapping, logConsumer) {
             initEnhancedRemapper(intermediaryMap, modLoadingQueue)
         }
         enhancedMojangRemapper = KiltEnhancedRemapper(mojangClassProvider, devMojangIntermediaryMapping, logConsumer) {
@@ -365,7 +365,7 @@ object KiltRemapper {
         )
 
         if (FabricLoader.getInstance().isDevelopmentEnvironment)
-            enhancedSRGRemapper.initDevRemapper()
+            enhancedSrgRemapper.initDevRemapper()
 
         suspend fun remapMod(file: Path, mod: ModDefinition) {
             val exception = RuntimeException("Failed to remap Forge mod ${mod.displayName} (${mod.id})!")
@@ -516,8 +516,8 @@ object KiltRemapper {
                         KiltHelper.mergeNullableCollections(originalNode.visibleAnnotations, originalNode.invisibleAnnotations)
                             .any { it.desc == MixinAdditionalRemapper.MIXIN_TYPE.descriptor }
                     ) {
-                        MixinRemapper.remapClass(originalNode, enhancedSRGRemapper, mixinRefmaps.values)
-                        MixinShadowRemapper.remapClass(originalNode, enhancedSRGRemapper)
+                        MixinRemapper.remapClass(originalNode, enhancedSrgRemapper, mixinRefmaps.values)
+                        MixinShadowRemapper.remapClass(originalNode, enhancedSrgRemapper)
 
                         if (!KiltFlags.DISABLE_FIXERS) {
                             MixinAdditionalRemapper.remapClass(originalNode)
@@ -528,7 +528,7 @@ object KiltRemapper {
                     }
 
                     val remappedNode = ClassNode(Opcodes.ASM9)
-                    originalNode.accept(EnhancedClassRemapper(remappedNode, enhancedSRGRemapper, RenamingTransformer(enhancedSRGRemapper, false)))
+                    originalNode.accept(EnhancedClassRemapper(remappedNode, enhancedSrgRemapper, RenamingTransformer(enhancedSrgRemapper, false)))
 
                     if (!KiltFlags.DISABLE_FIXERS) {
                         ConditionalInterfaceInjectionFixer.fixClass(remappedNode)
@@ -558,7 +558,7 @@ object KiltRemapper {
             }
             
             // If for whatever reason the refmap remapping missed something, we need to remap it immediately.
-            MixinRemapper.remapUnmappedRefmaps(mixinRefmaps.values, enhancedSRGRemapper)
+            MixinRemapper.remapUnmappedRefmaps(mixinRefmaps.values, enhancedSrgRemapper)
 
             // Now, let's write the refmap JSONs
             for ((entry, refmap) in mixinRefmaps) {

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
@@ -96,7 +96,7 @@ object KiltRemapper {
     // srg -> intermediary
     val srgIntermediaryMapping: IMappingFile = mappingFile.getMap("searge", "intermediary")
     // mojang -> intermediary
-    val mojIntermediaryMapping: IMappingFile = mappingFile.getMap("intermediary", "mojang").reverse()
+    private var mojIntermediaryMapping: IMappingFile? = mappingFile.getMap("intermediary", "mojang").reverse()
 
     val fabricMappings: INamedMappingFile = MappingConfiguration::class.java.classLoader.getResourceAsStream("mappings/mappings.tiny")!!.use { INamedMappingFile.load(it) }
 
@@ -107,9 +107,9 @@ object KiltRemapper {
             this
     }
 
-    private val devMojangIntermediaryMapping = mojIntermediaryMapping.run {
+    private var devMojangIntermediaryMapping = mojIntermediaryMapping.run {
         if (!forceProductionRemap)
-            this.rename(DevMappingRenamer(FabricLoader.getInstance().mappingResolver))
+            this?.rename(DevMappingRenamer(FabricLoader.getInstance().mappingResolver))
         else
             this
     }
@@ -128,7 +128,8 @@ object KiltRemapper {
     )
 
     lateinit var enhancedSrgRemapper: KiltEnhancedRemapper
-    lateinit var enhancedMojangRemapper: KiltEnhancedRemapper
+    var enhancedMojangRemapper: KiltEnhancedRemapper? = null
+        private set
 
     private lateinit var remappedModsDir: Path
 
@@ -139,8 +140,9 @@ object KiltRemapper {
     val srgMappedMethods =
         Object2ReferenceMaps.synchronize(Object2ReferenceOpenHashMap<String, MutableMap<String, String>>())
 
-    val mojangMappedMethods =
+    var mojangMappedMethods =
         Object2ReferenceMaps.synchronize(Object2ReferenceOpenHashMap<String, MutableMap<String, String>>())
+        private set
 
     fun fillMethodMappings(
         mappings: IMappingFile, methodMappings: Object2ReferenceMap<String, MutableMap<String, String>>,
@@ -168,6 +170,14 @@ object KiltRemapper {
                 }
             }.join()
         }
+    }
+
+    fun discardMojangMappings() {
+        enhancedMojangRemapper = null
+        mojangGamePath = null
+        mojangMappedMethods = null
+        mojIntermediaryMapping = null
+        devMojangIntermediaryMapping = null
     }
 
     init {
@@ -199,7 +209,9 @@ object KiltRemapper {
         }
 
         fillMethodMappings(srgIntermediaryMapping, srgMappedMethods, mappingResolver, forceProductionRemap)
-        fillMethodMappings(mojangIntermediaryMapping, mojangMappedMethods, mappingResolver, forceProductionRemap)
+        if (mojangIntermediaryMapping != null) {
+            fillMethodMappings(mojangIntermediaryMapping, mojangMappedMethods, mappingResolver, forceProductionRemap)
+        }
     }
 
     fun init() {}
@@ -334,7 +346,9 @@ object KiltRemapper {
         }
 
         srgGamePath = remapMinecraft("srg", devIntermediarySrgMapping)
-        mojangGamePath = remapMinecraft("mojang", devMojangIntermediaryMapping.reverse())
+        if (devMojangIntermediaryMapping != null) {
+            mojangGamePath = remapMinecraft("mojang", (devMojangIntermediaryMapping as IMappingFile).reverse())
+        }
 
         val exception = RuntimeException("Failed to remap Forge mods in Kilt!")
 
@@ -344,7 +358,7 @@ object KiltRemapper {
 
         // Use the regular mod file
         val srgClassProvider = createClassProvider(srgGamePath, modLoadingQueue)
-        val mojangClassProvider = createClassProvider(mojangGamePath, modLoadingQueue)
+        val mojangClassProvider = if (mojangGamePath != null) createClassProvider(mojangGamePath as Path, modLoadingQueue) else null
 
         val intermediaryMap = if (FabricLoader.getInstance().isDevelopmentEnvironment && !forceProductionRemap)
             remapMinecraft("intermediary", fabricMappings.getMap("named", "intermediary").rename(DevMojClassMappingRenamer(FabricLoader.getInstance().mappingResolver)))
@@ -354,8 +368,10 @@ object KiltRemapper {
         enhancedSrgRemapper = KiltEnhancedRemapper(srgClassProvider, devSrgIntermediaryMapping, logConsumer) {
             initEnhancedRemapper(intermediaryMap, modLoadingQueue)
         }
-        enhancedMojangRemapper = KiltEnhancedRemapper(mojangClassProvider, devMojangIntermediaryMapping, logConsumer) {
-            initEnhancedRemapper(intermediaryMap, modLoadingQueue)
+        if (devMojangIntermediaryMapping != null && mojangClassProvider != null) {
+            enhancedMojangRemapper = KiltEnhancedRemapper(mojangClassProvider, devMojangIntermediaryMapping as IMappingFile, logConsumer) {
+                initEnhancedRemapper(intermediaryMap, modLoadingQueue)
+            }
         }
 
         //val mixinRemapper = KiltMixinRemapper(enhancedRemapper, srgIntermediaryMapping, classProvider)
@@ -658,7 +674,7 @@ object KiltRemapper {
 
     val gameFile = getMCGameFile()
     lateinit var srgGamePath: Path
-    lateinit var mojangGamePath: Path
+    private var mojangGamePath: Path? = null
 
     private fun getDeobfJarDir(gameDir: Path, gameId: String, gameVersion: String): Path {
         return GameProviderHelper::class.java

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import it.unimi.dsi.fastutil.objects.Object2ReferenceMap
 import it.unimi.dsi.fastutil.objects.Object2ReferenceMaps
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap
 import kotlinx.coroutines.*
@@ -106,6 +107,13 @@ object KiltRemapper {
             this
     }
 
+    private val devMojangIntermediaryMapping = intermediaryMojMapping.run {
+        if (!forceProductionRemap)
+            this.rename(DevMappingRenamer(FabricLoader.getInstance().mappingResolver))
+        else
+            this
+    }
+
     val intermediarySrgMapping: IMappingFile = srgIntermediaryMapping.reverse()
     private val devIntermediarySrgMapping = devSrgIntermediaryMapping.reverse()
 
@@ -119,7 +127,8 @@ object KiltRemapper {
         this::class.java.getResourceAsStream("/kilt_workaround_mappings.tiny")!!.bufferedReader()
     )
 
-    lateinit var enhancedRemapper: KiltEnhancedRemapper
+    lateinit var enhancedSRGRemapper: KiltEnhancedRemapper
+    lateinit var enhancedMojangRemapper: KiltEnhancedRemapper
 
     private lateinit var remappedModsDir: Path
 
@@ -130,12 +139,45 @@ object KiltRemapper {
     val srgMappedMethods =
         Object2ReferenceMaps.synchronize(Object2ReferenceOpenHashMap<String, MutableMap<String, String>>())
 
+    val mojangMappedMethods =
+        Object2ReferenceMaps.synchronize(Object2ReferenceOpenHashMap<String, MutableMap<String, String>>())
+
+    fun fillMethodMappings(
+        mappings: IMappingFile, methodMappings: Object2ReferenceMap<String, MutableMap<String, String>>,
+        resolver: MappingResolver, forceProductionRemap: Boolean
+    ) {
+        runBlocking {
+            launch(Dispatchers.IO) {
+                mappings.classes.asFlow().concurrent().collect {
+                    it.methods.asFlow().concurrent().collect { f ->
+                        val map = methodMappings.getOrPut(f.original) {
+                            Object2ReferenceMaps.synchronize(Object2ReferenceOpenHashMap())
+                        }
+                        val mapped = if (!forceProductionRemap)
+                            resolver.mapMethodName(
+                                "intermediary",
+                                it.mapped.replace("/", "."),
+                                f.mapped,
+                                f.mappedDescriptor
+                            )
+                        else
+                            f.mapped
+
+                        map[f.parent.original] = mapped
+                    }
+                }
+            }.join()
+        }
+    }
+
     init {
         // Magical field references that are required because otherwise the remapper will deadlock
         val srgIntermediaryMapping = devSrgIntermediaryMapping
+        val mojangIntermediaryMapping = devMojangIntermediaryMapping
         val forceProductionRemap = forceProductionRemap
         val mappingResolver = mappingResolver
         val srgMappedMethods = srgMappedMethods
+        val mojangMappedMethods = mojangMappedMethods
 
         srgMappedFields = runBlocking {
             async(Dispatchers.IO) {
@@ -156,31 +198,58 @@ object KiltRemapper {
             }.await()
         }
 
-        runBlocking {
-            launch(Dispatchers.IO) {
-                srgIntermediaryMapping.classes.asFlow().concurrent().collect {
-                    it.methods.asFlow().concurrent().collect { f ->
-                        val map = srgMappedMethods.getOrPut(f.original) {
-                            Object2ReferenceMaps.synchronize(Object2ReferenceOpenHashMap())
-                        }
-                        val mapped = if (!forceProductionRemap)
-                            mappingResolver.mapMethodName(
-                                "intermediary",
-                                it.mapped.replace("/", "."),
-                                f.mapped,
-                                f.mappedDescriptor
-                            )
-                        else
-                            f.mapped
-
-                        map[f.parent.original] = mapped
-                    }
-                }
-            }.join()
-        }
+        fillMethodMappings(srgIntermediaryMapping, srgMappedMethods, mappingResolver, forceProductionRemap)
+        fillMethodMappings(mojangIntermediaryMapping, mojangMappedMethods, mappingResolver, forceProductionRemap)
     }
 
     fun init() {}
+
+    private fun initEnhancedRemapper(intermediaryMap: Path?, modLoadingQueue: List<ModDefinition>): ClassProvider {
+        // Initialize this a bit later, cuz we need the same libraries.
+        return ClassProvider.builder().apply {
+            // time to add Intermediary mappings to the mix! :,D
+            if (FabricLoader.getInstance().isDevelopmentEnvironment && !forceProductionRemap) {
+                addLibrary(intermediaryMap)
+            }
+
+            // IMPORTANT: this cannot be a flow or use merge, otherwise the order isn't retained. srgGamePath MUST be at the top of the list.
+            listOf(
+                // List down Forge paths
+                *KiltHelper.getKiltPaths().toTypedArray(),
+                // Add all Fabric mods
+                *FabricLoader.getInstance().allMods
+                    .flatMap { container -> container.rootPaths }.toTypedArray(),
+                // add mapped path too
+                *runBlocking { getGameClassPath() },
+                // Add all Forge mods to the library path, because dependencies don't have to be specified
+                // in order to use mods lmao
+                *modLoadingQueue.map { mod -> mod.path }.toTypedArray()
+            ).forEach {
+                addLibrary(it)
+            }
+        }.build()
+    }
+
+    private suspend fun createClassProvider(gamePath: Path, modLoadingQueue: List<ModDefinition>): ClassProvider {
+        return ClassProvider.builder().apply {
+            // IMPORTANT: this cannot be a flow or use merge, otherwise the order isn't retained. gamePath MUST be at the top of the list.
+            listOf(
+                gamePath,
+                // List down Forge paths
+                *KiltHelper.getKiltPaths().toTypedArray(),
+                // Add all Fabric mods
+                *FabricLoader.getInstance().allMods
+                    .flatMap { container -> container.rootPaths }.toTypedArray(),
+                // add mapped path too
+                *getGameClassPath(),
+                // Add all Forge mods to the library path, because dependencies don't have to be specified
+                // in order to use mods lmao
+                *modLoadingQueue.map { mod -> mod.path }.toTypedArray()
+            ).forEach {
+                addLibrary(it)
+            }
+        }.build()
+    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     suspend fun remapMods(definitions: Collection<ModDefinition>, remappedModsDir: Path) {
@@ -265,6 +334,7 @@ object KiltRemapper {
         }
 
         srgGamePath = remapMinecraft("srg", devIntermediarySrgMapping)
+        mojangGamePath = remapMinecraft("mojang", devMojangIntermediaryMapping.reverse())
 
         val exception = RuntimeException("Failed to remap Forge mods in Kilt!")
 
@@ -273,54 +343,19 @@ object KiltRemapper {
         val mods = modLoadingQueue.filter { !it.isBuiltin }.toSet()
 
         // Use the regular mod file
-        val classProvider = ClassProvider.builder().apply {
-            // IMPORTANT: this cannot be a flow or use merge, otherwise the order isn't retained. srgGamePath MUST be at the top of the list.
-            listOf(
-                srgGamePath,
-                // List down Forge paths
-                *KiltHelper.getKiltPaths().toTypedArray(),
-                // Add all Fabric mods
-                *FabricLoader.getInstance().allMods
-                    .flatMap { container -> container.rootPaths }.toTypedArray(),
-                // add mapped path too
-                *getGameClassPath(),
-                // Add all Forge mods to the library path, because dependencies don't have to be specified
-                // in order to use mods lmao
-                *modLoadingQueue.map { mod -> mod.path }.toTypedArray()
-            ).forEach {
-                addLibrary(it)
-            }
-        }.build()
+        val srgClassProvider = createClassProvider(srgGamePath, modLoadingQueue)
+        val mojangClassProvider = createClassProvider(mojangGamePath, modLoadingQueue)
 
         val intermediaryMap = if (FabricLoader.getInstance().isDevelopmentEnvironment && !forceProductionRemap)
             remapMinecraft("intermediary", fabricMappings.getMap("named", "intermediary").rename(DevMojClassMappingRenamer(FabricLoader.getInstance().mappingResolver)))
         else null
 
         // Initialize a global remapper state
-        enhancedRemapper = KiltEnhancedRemapper(classProvider, devSrgIntermediaryMapping, logConsumer) {
-            // Initialize this a bit later, cuz we need the same libraries.
-            ClassProvider.builder().apply {
-                // time to add Intermediary mappings to the mix! :,D
-                if (FabricLoader.getInstance().isDevelopmentEnvironment && !forceProductionRemap) {
-                    addLibrary(intermediaryMap)
-                }
-
-                // IMPORTANT: this cannot be a flow or use merge, otherwise the order isn't retained. srgGamePath MUST be at the top of the list.
-                listOf(
-                    // List down Forge paths
-                    *KiltHelper.getKiltPaths().toTypedArray(),
-                    // Add all Fabric mods
-                    *FabricLoader.getInstance().allMods
-                        .flatMap { container -> container.rootPaths }.toTypedArray(),
-                    // add mapped path too
-                    *runBlocking { getGameClassPath() },
-                    // Add all Forge mods to the library path, because dependencies don't have to be specified
-                    // in order to use mods lmao
-                    *modLoadingQueue.map { mod -> mod.path }.toTypedArray()
-                ).forEach {
-                    addLibrary(it)
-                }
-            }.build()
+        enhancedSRGRemapper = KiltEnhancedRemapper(srgClassProvider, devSrgIntermediaryMapping, logConsumer) {
+            initEnhancedRemapper(intermediaryMap, modLoadingQueue)
+        }
+        enhancedMojangRemapper = KiltEnhancedRemapper(mojangClassProvider, devMojangIntermediaryMapping, logConsumer) {
+            initEnhancedRemapper(intermediaryMap, modLoadingQueue)
         }
 
         //val mixinRemapper = KiltMixinRemapper(enhancedRemapper, srgIntermediaryMapping, classProvider)
@@ -330,7 +365,7 @@ object KiltRemapper {
         )
 
         if (FabricLoader.getInstance().isDevelopmentEnvironment)
-            enhancedRemapper.initDevRemapper()
+            enhancedSRGRemapper.initDevRemapper()
 
         suspend fun remapMod(file: Path, mod: ModDefinition) {
             val exception = RuntimeException("Failed to remap Forge mod ${mod.displayName} (${mod.id})!")
@@ -481,8 +516,8 @@ object KiltRemapper {
                         KiltHelper.mergeNullableCollections(originalNode.visibleAnnotations, originalNode.invisibleAnnotations)
                             .any { it.desc == MixinAdditionalRemapper.MIXIN_TYPE.descriptor }
                     ) {
-                        MixinRemapper.remapClass(originalNode, enhancedRemapper, mixinRefmaps.values)
-                        MixinShadowRemapper.remapClass(originalNode, enhancedRemapper)
+                        MixinRemapper.remapClass(originalNode, enhancedSRGRemapper, mixinRefmaps.values)
+                        MixinShadowRemapper.remapClass(originalNode, enhancedSRGRemapper)
 
                         if (!KiltFlags.DISABLE_FIXERS) {
                             MixinAdditionalRemapper.remapClass(originalNode)
@@ -493,7 +528,7 @@ object KiltRemapper {
                     }
 
                     val remappedNode = ClassNode(Opcodes.ASM9)
-                    originalNode.accept(EnhancedClassRemapper(remappedNode, enhancedRemapper, RenamingTransformer(enhancedRemapper, false)))
+                    originalNode.accept(EnhancedClassRemapper(remappedNode, enhancedSRGRemapper, RenamingTransformer(enhancedSRGRemapper, false)))
 
                     if (!KiltFlags.DISABLE_FIXERS) {
                         ConditionalInterfaceInjectionFixer.fixClass(remappedNode)
@@ -523,7 +558,7 @@ object KiltRemapper {
             }
             
             // If for whatever reason the refmap remapping missed something, we need to remap it immediately.
-            MixinRemapper.remapUnmappedRefmaps(mixinRefmaps.values, enhancedRemapper)
+            MixinRemapper.remapUnmappedRefmaps(mixinRefmaps.values, enhancedSRGRemapper)
 
             // Now, let's write the refmap JSONs
             for ((entry, refmap) in mixinRefmaps) {
@@ -623,6 +658,7 @@ object KiltRemapper {
 
     val gameFile = getMCGameFile()
     lateinit var srgGamePath: Path
+    lateinit var mojangGamePath: Path
 
     private fun getDeobfJarDir(gameDir: Path, gameId: String, gameVersion: String): Path {
         return GameProviderHelper::class.java

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
@@ -19,6 +19,181 @@ object MixinRemapper {
     private val ACCESSOR_TYPE = Type.getType(Accessor::class.java)
     private val INVOKER_TYPE = Type.getType(Invoker::class.java)
 
+    fun remapMixinAnnotation(
+        annotationNode: AnnotationNode,
+        remapper: KiltEnhancedRemapper,
+        classTargets: Collection<String>,
+        mixinClassName: String?,
+        mixinMapping: MutableMap<String, String> = mutableMapOf(),
+        alreadyRefmapped: MutableSet<String> = Collections.synchronizedSet(mutableSetOf<String>()),
+        refmap: MixinRefmap? = null
+    ): AnnotationNode {
+        if (annotationNode.values == null)
+            return annotationNode
+
+        val values = KiltMixinModifications.annotationValuesToMap(annotationNode.values).toMutableMap()
+
+        // Remap accessor/invoker
+        if (annotationNode.desc == ACCESSOR_TYPE.descriptor || annotationNode.desc == INVOKER_TYPE.descriptor) {
+            if (!values.contains("value"))
+                return annotationNode
+
+            val value = values["value"] as String
+
+            if (mixinMapping.contains(value)) {
+                if (!alreadyRefmapped.add(value))
+                    return annotationNode
+
+                val mapped = remapTargetString(mixinMapping[value]!!, classTargets, remapper)
+                mixinMapping[value] = mapped
+            } else {
+                values["value"] = remapTargetString(value, classTargets, remapper)
+                annotationNode.values = KiltMixinModifications.mapToAnnotationValues(values)
+            }
+
+            return annotationNode
+        }
+
+        fun tryRemapMixinRefmap(value: String): String {
+            // Do NOT remap this - this typically indicates MixinSquared or other extensions.
+            if (value.startsWith("@"))
+                return value
+
+            return if (mixinMapping.contains(value)) {
+                if (!alreadyRefmapped.add(value))
+                    return value
+
+                val original = mixinMapping[value]!!
+                val mapped = remapTargetString(original, classTargets, remapper)
+
+                mixinMapping[value] = mapped
+
+                value
+            } else {
+                val mapped = remapTargetString(value, classTargets, remapper)
+
+                if (refmap != null) {
+                    mixinMapping[value] = mapped
+                    return value
+                }
+
+                mapped
+            }
+        }
+
+        // We cannot search for mixin annotations specifically, because there's a chance
+        // we might miss custom annotations.
+        // Usually this can be a good indicator of a mixin annotation.
+        if (values.containsKey("method")) {
+            val methodValue = values["method"]!!
+
+            if (methodValue is String) {
+                values["method"] = tryRemapMixinRefmap(methodValue)
+            } else if (methodValue is List<*>) {
+                values["method"] = methodValue.map {
+                    tryRemapMixinRefmap(it as String)
+                }
+            }
+        }
+
+        fun remapAtValue(atValue: AnnotationNode) {
+            if (atValue.values == null)
+                return
+
+            val atValues = KiltMixinModifications.annotationValuesToMap(atValue.values).toMutableMap()
+
+            // Remap targets
+            if (atValues.contains("target")) {
+                val targetValue = atValues["target"]!!
+
+                if (targetValue is String) {
+                    atValues["target"] = tryRemapMixinRefmap(targetValue)
+                }
+            }
+
+            if (atValues.contains("desc")) {
+                // TODO: i'm not even going to try.
+                KiltRemapper.logger.error("!! Tell BluSpring to stop being lazy. $mixinClassName")
+            }
+
+            atValue.values = KiltMixinModifications.mapToAnnotationValues(atValues)
+        }
+
+        // This can also be a very good indicator, but it's a little weird
+        if (values.containsKey("at")) {
+            val atValue = values["at"]!!
+
+            if (atValue is AnnotationNode) {
+                remapAtValue(atValue)
+            } else if (atValue is List<*>) {
+                val newList = mutableListOf<Any?>()
+
+                for (atValueIndiv in atValue) {
+                    if (atValueIndiv is AnnotationNode)
+                        remapAtValue(atValueIndiv)
+
+                    newList.add(atValueIndiv)
+                }
+
+                values["at"] = newList
+            }
+        }
+
+        // This one's also a lot stranger, but needs to be handled
+        if (values.contains("slice")) {
+            fun remapSliceValue(sliceValue: AnnotationNode) {
+                if (sliceValue.values == null)
+                    return
+
+                val sliceValues = KiltMixinModifications.annotationValuesToMap(sliceValue.values).toMutableMap()
+
+                if (sliceValues.contains("from") && sliceValues["from"] is AnnotationNode) {
+                    sliceValues["from"] = remapAtValue(sliceValues["from"] as AnnotationNode)
+                }
+
+                if (sliceValues.contains("to") && sliceValues["to"] is AnnotationNode) {
+                    sliceValues["to"] = remapAtValue(sliceValues["to"] as AnnotationNode)
+                }
+            }
+
+            val sliceValue = values["slice"]!!
+
+            if (sliceValue is AnnotationNode) {
+                remapSliceValue(sliceValue)
+            } else if (sliceValue is List<*>) {
+                val newSliceValues = mutableListOf<Any?>()
+
+                for (sliceValue in sliceValue) {
+                    if (sliceValue is AnnotationNode) {
+                        remapSliceValue(sliceValue)
+                    } else {
+                        newSliceValues.add(sliceValue)
+                    }
+                }
+
+                values["slice"] = newSliceValues
+            }
+        }
+
+        // Now to change the values list
+        annotationNode.values = KiltMixinModifications.mapToAnnotationValues(values)
+        return annotationNode
+    }
+
+    fun remapMixinAnnotations(
+        annotations: MutableList<AnnotationNode>,
+        remapper: KiltEnhancedRemapper,
+        classTargets: Collection<String>,
+        mixinClassName: String?,
+        mixinMapping: MutableMap<String, String> = mutableMapOf(),
+        alreadyRefmapped: MutableSet<String> = Collections.synchronizedSet(mutableSetOf<String>()),
+        refmap: MixinRefmap? = null
+    ) {
+        for (annotationNode in annotations) {
+            remapMixinAnnotation(annotationNode, remapper, classTargets, mixinClassName, mixinMapping, alreadyRefmapped, refmap)
+        }
+    }
+
     fun remapClass(classNode: ClassNode, remapper: KiltEnhancedRemapper, refmaps: Collection<MixinRefmap>) {
         val alreadyRefmapped = Collections.synchronizedSet(mutableSetOf<String>())
 
@@ -37,166 +212,18 @@ object MixinRemapper {
         // The idea is if we don't have a matching mapping, we need to remap directly on the string instead.
 
         for (method in classNode.methods) {
-            fun remapMixinAnnotations(annotations: MutableList<AnnotationNode>) {
-                for (annotationNode in annotations) {
-                    if (annotationNode.values == null)
-                        continue
-
-                    val values = KiltMixinModifications.annotationValuesToMap(annotationNode.values).toMutableMap()
-
-                    // Remap accessor/invoker
-                    if (annotationNode.desc == ACCESSOR_TYPE.descriptor || annotationNode.desc == INVOKER_TYPE.descriptor) {
-                        if (!values.contains("value"))
-                            continue
-
-                        val value = values["value"] as String
-
-                        if (mixinMapping.contains(value)) {
-                            if (!alreadyRefmapped.add(value))
-                                continue
-
-                            val mapped = remapTargetString(mixinMapping[value]!!, classTargets, remapper)
-                            mixinMapping[value] = mapped
-                        } else {
-                            values["value"] = remapTargetString(value, classTargets, remapper)
-                            annotationNode.values = KiltMixinModifications.mapToAnnotationValues(values)
-                        }
-
-                        continue
-                    }
-
-                    fun tryRemapMixinRefmap(value: String): String {
-                        // Do NOT remap this - this typically indicates MixinSquared or other extensions.
-                        if (value.startsWith("@"))
-                            return value
-
-                        return if (mixinMapping.contains(value)) {
-                            if (!alreadyRefmapped.add(value))
-                                return value
-
-                            val original = mixinMapping[value]!!
-                            val mapped = remapTargetString(original, classTargets, remapper)
-
-                            mixinMapping[value] = mapped
-
-                            value
-                        } else {
-                            val mapped = remapTargetString(value, classTargets, remapper)
-
-                            if (refmap != null) {
-                                mixinMapping[value] = mapped
-                                return value
-                            }
-
-                            mapped
-                        }
-                    }
-
-                    // We cannot search for mixin annotations specifically, because there's a chance
-                    // we might miss custom annotations.
-                    // Usually this can be a good indicator of a mixin annotation.
-                    if (values.containsKey("method")) {
-                        val methodValue = values["method"]!!
-
-                        if (methodValue is String) {
-                            values["method"] = tryRemapMixinRefmap(methodValue)
-                        } else if (methodValue is List<*>) {
-                            values["method"] = methodValue.map {
-                                tryRemapMixinRefmap(it as String)
-                            }
-                        }
-                    }
-
-                    fun remapAtValue(atValue: AnnotationNode) {
-                        if (atValue.values == null)
-                            return
-
-                        val atValues = KiltMixinModifications.annotationValuesToMap(atValue.values).toMutableMap()
-
-                        // Remap targets
-                        if (atValues.contains("target")) {
-                            val targetValue = atValues["target"]!!
-
-                            if (targetValue is String) {
-                                atValues["target"] = tryRemapMixinRefmap(targetValue)
-                            }
-                        }
-
-                        if (atValues.contains("desc")) {
-                            // TODO: i'm not even going to try.
-                            KiltRemapper.logger.error("!! Tell BluSpring to stop being lazy. ${classNode.name}")
-                        }
-
-                        atValue.values = KiltMixinModifications.mapToAnnotationValues(atValues)
-                    }
-
-                    // This can also be a very good indicator, but it's a little weird
-                    if (values.containsKey("at")) {
-                        val atValue = values["at"]!!
-
-                        if (atValue is AnnotationNode) {
-                            remapAtValue(atValue)
-                        } else if (atValue is List<*>) {
-                            val newList = mutableListOf<Any?>()
-
-                            for (atValueIndiv in atValue) {
-                                if (atValueIndiv is AnnotationNode)
-                                    remapAtValue(atValueIndiv)
-
-                                newList.add(atValueIndiv)
-                            }
-
-                            values["at"] = newList
-                        }
-                    }
-
-                    // This one's also a lot stranger, but needs to be handled
-                    if (values.contains("slice")) {
-                        fun remapSliceValue(sliceValue: AnnotationNode) {
-                            if (sliceValue.values == null)
-                                return
-
-                            val sliceValues = KiltMixinModifications.annotationValuesToMap(sliceValue.values).toMutableMap()
-
-                            if (sliceValues.contains("from") && sliceValues["from"] is AnnotationNode) {
-                                sliceValues["from"] = remapAtValue(sliceValues["from"] as AnnotationNode)
-                            }
-
-                            if (sliceValues.contains("to") && sliceValues["to"] is AnnotationNode) {
-                                sliceValues["to"] = remapAtValue(sliceValues["to"] as AnnotationNode)
-                            }
-                        }
-
-                        val sliceValue = values["slice"]!!
-
-                        if (sliceValue is AnnotationNode) {
-                            remapSliceValue(sliceValue)
-                        } else if (sliceValue is List<*>) {
-                            val newSliceValues = mutableListOf<Any?>()
-
-                            for (sliceValue in sliceValue) {
-                                if (sliceValue is AnnotationNode) {
-                                    remapSliceValue(sliceValue)
-                                } else {
-                                    newSliceValues.add(sliceValue)
-                                }
-                            }
-
-                            values["slice"] = newSliceValues
-                        }
-                    }
-
-                    // Now to change the values list
-                    annotationNode.values = KiltMixinModifications.mapToAnnotationValues(values)
-                }
-            }
-
             if (method.visibleAnnotations != null) {
-                remapMixinAnnotations(method.visibleAnnotations!!.toMutableList())
+                remapMixinAnnotations(
+                    method.visibleAnnotations!!.toMutableList(), remapper, classTargets, classNode.name,
+                    mixinMapping, alreadyRefmapped, refmap
+                )
             }
 
             if (method.invisibleAnnotations != null) {
-                remapMixinAnnotations(method.invisibleAnnotations!!.toMutableList())
+                remapMixinAnnotations(
+                    method.invisibleAnnotations!!.toMutableList(), remapper, classTargets, classNode.name,
+                    mixinMapping, alreadyRefmapped, refmap
+                )
             }
         }
 


### PR DESCRIPTION
This makes the current modifications specified in KiltMixinModifications work in production without having to translate them to SRG.
It also makes sure annotation replacements are properly remapped (hence why I changed MixinRemapper so the remapAnnotations function is now exposed).

Since there are 2 enhanced remappers I renamed the old one to enhancedSRGRemapper to minimise confusion.
The rest of the changes are mostly putting stuff into functions so we can reuse the same code for SRG and Mojang.

It should be noted that method remapping in KiltMixinModifications still uses SRG primarily and only falls back to Mojang mappings when no SRG name is found, whereas ReplacedAnnotationsModifier and NameRemappingAnnotationModifier only remap to Mojang mappings.

Do you think I should remove the srg mapping from KiltMixinModifications::remapMethod?