### PR TITLE
Fix mods loading on the wrong side.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -694,6 +694,7 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
         // I hope.
         var hasInitialized = false
         var hasErrored = false
+        var annotationCount = 0
 
         val constructorArgs = mapOf<Class<*>, Any?>(
             IEventBus::class.java to mod.eventBus,
@@ -720,6 +721,7 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
                     if (dist is Collection<*> && !dist.contains(FMLLoader.getDist())) {
                         return@collect
                     }
+                    annotationCount++
 
                     ModLoadingContext.get().activeContainer = mod.container
 
@@ -771,7 +773,7 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
                 }
             }
 
-        if (!hasInitialized && mod.shouldScan && !mod.modId.startsWith("jij_") && !hasErrored) {
+        if (!hasInitialized && mod.shouldScan && !mod.modId.startsWith("jij_") && !hasErrored && annotationCount != 0) {
             exception.addSuppressed(IllegalStateException("Mod ID ${mod.modId} is an invalid Java FML mod!"))
         }
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -716,6 +716,11 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
                     if (modId != mod.modId)
                         return@collect
 
+                    val dist = it.annotationData["dist"]
+                    if (dist is Collection<*> && !dist.contains(FMLLoader.getDist())) {
+                        return@collect
+                    }
+
                     ModLoadingContext.get().activeContainer = mod.container
 
                     val clazz = launcher.loadIntoTarget(it.clazz.className)


### PR DESCRIPTION
It seems the 1.21.1 version loads all mod annotations regardless of what dist parameters are set, causing Kilt to load client-only mod annotations on servers and vice versa.
This is problematic because it will usually lead to mods accessing client-only classes on servers, which usually results in a crash.

This pull request solves that, and stops the game from crashing if no annotations were found (otherwise flywheel still crashes).