### PR TITLE
Automodpack Support (1.21.1 Edition)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,6 +100,10 @@ allprojects {
             name = "devOS Maven"
         }
 
+        maven("https://maven.florianreuth.de/snapshots") {
+            name = "AsmFabricLoader"
+        }
+
         maven("https://mvn.devos.one/snapshots/") {
             name = "devOS Maven (Snapshots)"
         }
@@ -223,7 +227,7 @@ allprojects {
             implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${rootProject.property("mixin_squared_version")}") {
                 exclude("org.ow2.asm")
             })
-            modApi("xyz.bluspring:AsmFabricLoader:${property("asmfabricloader_version")}") {
+            modApi("de.florianreuth:asmfabricloader:${property("asmfabricloader_version")}") {
                 exclude("org.ow2.asm")
             }
         }
@@ -242,7 +246,7 @@ dependencies {
     include("com.github.FabricCompatibilityLayers.CursedMixinExtensions:CursedMixinExtensions:${property("cursedmixinextensions_version")}")
     include("com.github.Chocohead:Fabric-ASM:v${property("fabric_asm_version")}")
     include("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${rootProject.property("mixin_squared_version")}")
-    include("xyz.bluspring:AsmFabricLoader:${property("asmfabricloader_version")}")
+    include("de.florianreuth:asmfabricloader:${property("asmfabricloader_version")}")
     include("com.moulberry:mixinconstraints:${rootProject.property("mixinconstraints_version")}") {
         exclude("org.spongepowered", "mixin")
     }

--- a/compat/fabric-compats/build.gradle.kts
+++ b/compat/fabric-compats/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
     modCompileOnly("maven.modrinth:pehkui:${property("pehkui_version")}")
 
     modCompileOnly("dev.architectury:architectury-fabric:${property("architectury_version")}")
+
+    modCompileOnly("maven.modrinth:automodpack:${property("automodpack_version")}")
 }
 
 tasks {

--- a/compat/fabric-compats/gradle.properties
+++ b/compat/fabric-compats/gradle.properties
@@ -40,3 +40,6 @@ pehkui_version = 3.8.3+1.14.4-1.21
 
 # https://modrinth.com/mod/architectury-api/versions?g=1.21.1
 architectury_version = 13.0.8
+
+# https://modrinth.com/mod/automodpack/versions?g=1.21.1
+automodpack_version=4.0.5-fabric,1.21.1

--- a/compat/fabric-compats/src/main/kotlin/xyz/bluspring/kilt/compat/fabric/KiltFabricCompatsKnitExtension.kt
+++ b/compat/fabric-compats/src/main/kotlin/xyz/bluspring/kilt/compat/fabric/KiltFabricCompatsKnitExtension.kt
@@ -1,0 +1,20 @@
+package xyz.bluspring.kilt.compat.fabric
+
+import net.fabricmc.loader.api.FabricLoader
+import xyz.bluspring.kilt.compat.fabric.automodpack.KiltAutoModpackCompat
+import xyz.bluspring.knit.loader.api.KnitNativeModCompatExtension
+import xyz.bluspring.knit.loader.api.KnitModScanSetupApi
+
+class KiltFabricCompatsKnitExtension : KnitNativeModCompatExtension {
+
+    override fun setupModScanning(api: KnitModScanSetupApi) {
+        if (FabricLoader.getInstance().isModLoaded("automodpack")) {
+            KiltAutoModpackCompat.modpackDir?.let { path ->
+                for (modDir in api.loader.modDirs) {
+                    if (modDir.isAbsolute) continue
+                    api.addModDirectory(path.resolve(modDir))
+                }
+            }
+        }
+    }
+}

--- a/compat/fabric-compats/src/main/kotlin/xyz/bluspring/kilt/compat/fabric/automodpack/KiltAutoModpackCompat.kt
+++ b/compat/fabric-compats/src/main/kotlin/xyz/bluspring/kilt/compat/fabric/automodpack/KiltAutoModpackCompat.kt
@@ -1,0 +1,11 @@
+package xyz.bluspring.kilt.compat.fabric.automodpack
+
+import pl.skidam.automodpack_core.GlobalVariables
+import java.nio.file.Path
+
+object KiltAutoModpackCompat {
+
+    val modpackDir: Path?
+        get() = GlobalVariables.selectedModpackDir
+
+}

--- a/compat/fabric-compats/src/main/resources/META-INF/services/xyz.bluspring.knit.loader.api.KnitNativeModCompatExtension
+++ b/compat/fabric-compats/src/main/resources/META-INF/services/xyz.bluspring.knit.loader.api.KnitNativeModCompatExtension
@@ -1,0 +1,1 @@
+xyz.bluspring.kilt.compat.fabric.KiltFabricCompatsKnitExtension

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,8 +49,8 @@ fabric_asm_version=2.3
 # https://github.com/Bawnorton/MixinSquared/releases
 mixin_squared_version=0.3.3
 
-# custom fork https://mvn.devos.one/#/snapshots/xyz/bluspring/AsmFabricLoader
-asmfabricloader_version=2.0.2-SNAPSHOT
+# https://maven.florianreuth.de/#/snapshots/de/florianreuth/asmfabricloader
+asmfabricloader_version=2.1.1-SNAPSHOT
 
 # https://github.com/Moulberry/MixinConstraints
 mixinconstraints_version=1.0.8

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltInstrumentationHandler.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltInstrumentationHandler.kt
@@ -1,6 +1,6 @@
 package xyz.bluspring.kilt.loader.asm
 
-import de.florianmichael.asmfabricloader.api.event.InstrumentationEntrypoint
+import de.florianreuth.asmfabricloader.api.event.InstrumentationEntrypoint
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes


### PR DESCRIPTION
Basically just #715 again but without the networking hack.

Also updates to AsmFabricLoader version 2.1.1 and now targets KnitLoader/main instead of KnitLoader/1.21.1.

Depends on https://github.com/KiltMC/KnitLoader/pull/2