### PR TITLE
Search recursively for side-only lambdas.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/EnvironmentLambdaFixer.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/EnvironmentLambdaFixer.kt
@@ -8,7 +8,7 @@ import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.InvokeDynamicInsnNode
 import org.objectweb.asm.tree.MethodNode
-import xyz.bluspring.kilt.util.KiltHelper
+import xyz.bluspring.kilt.util.KiltHelper.mergedAnnotations
 import java.lang.invoke.LambdaMetafactory
 
 object EnvironmentLambdaFixer {
@@ -16,16 +16,12 @@ object EnvironmentLambdaFixer {
     const val LAMBDA_METHOD_DESCRIPTOR = "(Ljava/lang/invoke/MethodHandles\$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"
     private val ENVIRONMENT_TYPE = Type.getType(Environment::class.java)
 
-    private fun getAnnotations(methodNode: MethodNode): Collection<AnnotationNode> {
-        return KiltHelper.mergeNullableCollections(methodNode.visibleAnnotations, methodNode.invisibleAnnotations)
-    }
-
     private fun lacksEnvAnnotation(annotations: Collection<AnnotationNode>): Boolean {
         return annotations.none { it.desc == ENVIRONMENT_TYPE.descriptor }
     }
 
     private fun lacksEnvAnnotation(methodNode: MethodNode): Boolean {
-        return lacksEnvAnnotation(getAnnotations(methodNode))
+        return lacksEnvAnnotation(methodNode.mergedAnnotations)
     }
 
     private fun markLambdas(
@@ -70,7 +66,7 @@ object EnvironmentLambdaFixer {
         val methodsToMark = mutableMapOf<Pair<String, String>, AnnotationNode>()
 
         for (methodNode in classNode.methods) {
-            val annotations = getAnnotations(methodNode)
+            val annotations = methodNode.mergedAnnotations
             if (lacksEnvAnnotation(annotations))
                 continue
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/EnvironmentLambdaFixer.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/EnvironmentLambdaFixer.kt
@@ -16,14 +16,6 @@ object EnvironmentLambdaFixer {
     const val LAMBDA_METHOD_DESCRIPTOR = "(Ljava/lang/invoke/MethodHandles\$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"
     private val ENVIRONMENT_TYPE = Type.getType(Environment::class.java)
 
-    private fun lacksEnvAnnotation(annotations: Collection<AnnotationNode>): Boolean {
-        return annotations.none { it.desc == ENVIRONMENT_TYPE.descriptor }
-    }
-
-    private fun lacksEnvAnnotation(methodNode: MethodNode): Boolean {
-        return lacksEnvAnnotation(methodNode.mergedAnnotations)
-    }
-
     private fun markLambdas(
         methodNode: MethodNode, classNode: ClassNode, envAnnotation: AnnotationNode,
         methodsToMark: MutableMap<Pair<String, String>, AnnotationNode>
@@ -56,7 +48,7 @@ object EnvironmentLambdaFixer {
             }
         }
         for (nestedNode in classNode.methods) {
-            if (nestedLambdas.contains(nestedNode.name) && lacksEnvAnnotation(nestedNode)) {
+            if (nestedLambdas.contains(nestedNode.name) && nestedNode.mergedAnnotations.none { it.desc == ENVIRONMENT_TYPE.descriptor }) {
                 markLambdas(nestedNode, classNode, envAnnotation, methodsToMark)
             }
         }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/EnvironmentLambdaFixer.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/EnvironmentLambdaFixer.kt
@@ -67,9 +67,6 @@ object EnvironmentLambdaFixer {
 
         for (methodNode in classNode.methods) {
             val annotations = methodNode.mergedAnnotations
-            if (lacksEnvAnnotation(annotations))
-                continue
-
             val envAnnotation = annotations.firstOrNull { it.desc == ENVIRONMENT_TYPE.descriptor } ?: continue
 
             markLambdas(methodNode, classNode, envAnnotation, methodsToMark)

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/EnvironmentLambdaFixer.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/EnvironmentLambdaFixer.kt
@@ -7,6 +7,7 @@ import org.objectweb.asm.Type
 import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.InvokeDynamicInsnNode
+import org.objectweb.asm.tree.MethodNode
 import xyz.bluspring.kilt.util.KiltHelper
 import java.lang.invoke.LambdaMetafactory
 
@@ -15,41 +16,67 @@ object EnvironmentLambdaFixer {
     const val LAMBDA_METHOD_DESCRIPTOR = "(Ljava/lang/invoke/MethodHandles\$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"
     private val ENVIRONMENT_TYPE = Type.getType(Environment::class.java)
 
-    fun fixClass(classNode: ClassNode) {
-        val methodsToMark = mutableMapOf<Pair<String, String>, AnnotationNode>()
+    private fun getAnnotations(methodNode: MethodNode): Collection<AnnotationNode> {
+        return KiltHelper.mergeNullableCollections(methodNode.visibleAnnotations, methodNode.invisibleAnnotations)
+    }
 
-        for (methodNode in classNode.methods) {
-            val annotations = KiltHelper.mergeNullableCollections(methodNode.visibleAnnotations, methodNode.invisibleAnnotations)
-            if (annotations.none { it.desc == ENVIRONMENT_TYPE.descriptor })
-                continue
+    private fun lacksEnvAnnotation(annotations: Collection<AnnotationNode>): Boolean {
+        return annotations.none { it.desc == ENVIRONMENT_TYPE.descriptor }
+    }
 
-            val envAnnotation = annotations.first { it.desc == ENVIRONMENT_TYPE.descriptor }
+    private fun lacksEnvAnnotation(methodNode: MethodNode): Boolean {
+        return lacksEnvAnnotation(getAnnotations(methodNode))
+    }
 
-            for (insnNode in methodNode.instructions) {
-                // Modified from Quilt - https://github.com/QuiltMC/quilt-loader/blob/develop/src/main/java/org/quiltmc/loader/impl/transformer/LambdaStripCalculator.java
-                if (insnNode is InvokeDynamicInsnNode) {
-                    if (Opcodes.H_INVOKESTATIC != insnNode.bsm.tag)
-                        continue
+    private fun markLambdas(
+        methodNode: MethodNode, classNode: ClassNode, envAnnotation: AnnotationNode,
+        methodsToMark: MutableMap<Pair<String, String>, AnnotationNode>
+    ) {
+        val nestedLambdas = mutableSetOf<String>()
+        for (insnNode in methodNode.instructions) {
+            // Modified from Quilt - https://github.com/QuiltMC/quilt-loader/blob/develop/src/main/java/org/quiltmc/loader/impl/transformer/LambdaStripCalculator.java
+            if (insnNode is InvokeDynamicInsnNode) {
+                if (Opcodes.H_INVOKESTATIC != insnNode.bsm.tag)
+                    continue
 
-                    if ("metafactory" != insnNode.bsm.name)
-                        continue
+                if ("metafactory" != insnNode.bsm.name)
+                    continue
 
-                    if (LAMBDA_CLASS_NAME != insnNode.bsm.owner)
-                        continue
+                if (LAMBDA_CLASS_NAME != insnNode.bsm.owner)
+                    continue
 
-                    if (LAMBDA_METHOD_DESCRIPTOR != insnNode.bsm.desc)
-                        continue
+                if (LAMBDA_METHOD_DESCRIPTOR != insnNode.bsm.desc)
+                    continue
 
-                    if (insnNode.bsmArgs?.size == 3) {
-                        if (insnNode.bsmArgs[1] is Handle) {
-                            val lambdaTarget = insnNode.bsmArgs[1] as Handle
-                            if (lambdaTarget.owner == classNode.name) {
-                                methodsToMark[Pair(lambdaTarget.name, lambdaTarget.desc)] = envAnnotation
-                            }
+                if (insnNode.bsmArgs?.size == 3) {
+                    if (insnNode.bsmArgs[1] is Handle) {
+                        val lambdaTarget = insnNode.bsmArgs[1] as Handle
+                        if (lambdaTarget.owner == classNode.name) {
+                            methodsToMark[Pair(lambdaTarget.name, lambdaTarget.desc)] = envAnnotation
+                            nestedLambdas.add(lambdaTarget.name)
                         }
                     }
                 }
             }
+        }
+        for (nestedNode in classNode.methods) {
+            if (nestedLambdas.contains(nestedNode.name) && lacksEnvAnnotation(nestedNode)) {
+                markLambdas(nestedNode, classNode, envAnnotation, methodsToMark)
+            }
+        }
+    }
+
+    fun fixClass(classNode: ClassNode) {
+        val methodsToMark = mutableMapOf<Pair<String, String>, AnnotationNode>()
+
+        for (methodNode in classNode.methods) {
+            val annotations = getAnnotations(methodNode)
+            if (lacksEnvAnnotation(annotations))
+                continue
+
+            val envAnnotation = annotations.first { it.desc == ENVIRONMENT_TYPE.descriptor }
+
+            markLambdas(methodNode, classNode, envAnnotation, methodsToMark)
         }
 
         for ((pair, annotationNode) in methodsToMark) {

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/EnvironmentLambdaFixer.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/EnvironmentLambdaFixer.kt
@@ -52,7 +52,7 @@ object EnvironmentLambdaFixer {
                     if (insnNode.bsmArgs[1] is Handle) {
                         val lambdaTarget = insnNode.bsmArgs[1] as Handle
                         if (lambdaTarget.owner == classNode.name) {
-                            methodsToMark[Pair(lambdaTarget.name, lambdaTarget.desc)] = envAnnotation
+                            methodsToMark[lambdaTarget.name to lambdaTarget.desc] = envAnnotation
                             nestedLambdas.add(lambdaTarget.name)
                         }
                     }
@@ -74,7 +74,7 @@ object EnvironmentLambdaFixer {
             if (lacksEnvAnnotation(annotations))
                 continue
 
-            val envAnnotation = annotations.first { it.desc == ENVIRONMENT_TYPE.descriptor }
+            val envAnnotation = annotations.firstOrNull { it.desc == ENVIRONMENT_TYPE.descriptor } ?: continue
 
             markLambdas(methodNode, classNode, envAnnotation, methodsToMark)
         }

--- a/src/main/kotlin/xyz/bluspring/kilt/util/KiltHelper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/KiltHelper.kt
@@ -6,7 +6,9 @@ import net.fabricmc.loader.impl.launch.FabricLauncherBase
 import net.minecraftforge.fml.ModLoadingContext
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.MethodNode
 import xyz.bluspring.kilt.Kilt
 import xyz.bluspring.kilt.loader.KiltFlags
 import xyz.bluspring.kilt.loader.KiltLoader
@@ -159,6 +161,9 @@ object KiltHelper {
 
         return list
     }
+
+    val MethodNode.mergedAnnotations: Collection<AnnotationNode>
+        get() = mergeNullableCollections(this.visibleAnnotations, this.invisibleAnnotations)
 
     private data class OverrideData(
         val superClass: Class<*>,


### PR DESCRIPTION
Currently it looks like Kilt only remaps lambdas found directly inside of `@Environment`-annotated methods, ignoring lambdas inside those lambdas. This is a problem because some mods like [The Aether: Redux](https://github.com/Zepalesque/The-Aether-Redux/blob/1.20.1/src/main/java/net/zepalesque/redux/client/particle/ReduxParticleTypes.java#L146) use nested lambdas  for client-only code. These lambdas don't have the `@Environment`-annotation during the initial search, which means only the first lambda is ever annotated, resulting in a serverside game crash because the Particle class could not be loaded.

This pull request resolves this by searching each found lambda for additional lambdas without the `@Environment`-annotation recursively, which seems to solve the problem.