### PR TITLE
Fix RarityInject and render forge style modifiers.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/client/gui/GuiInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/client/gui/GuiInject.java
@@ -9,12 +9,14 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 import com.mojang.blaze3d.platform.Window;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.BossHealthOverlay;
 import net.minecraft.client.gui.components.spectator.SpectatorGui;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -38,6 +40,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.bluspring.kilt.Kilt;
 import xyz.bluspring.kilt.client.KiltClient;
 import xyz.bluspring.kilt.injections.client.gui.GuiInjection;
+import xyz.bluspring.kilt.injections.world.item.RarityInjection;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -67,6 +70,9 @@ public abstract class GuiInject implements GuiInjection {
     @Shadow public int screenWidth;
     @Shadow public int screenHeight;
     @Shadow public abstract void renderSelectedItemName(GuiGraphics guiGraphics);
+
+    @Shadow
+    public ItemStack lastToolHighlight;
 
     @WrapOperation(method = "renderEffects", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/effect/MobEffectInstance;showIcon()Z"))
     private boolean kilt$checkIconVisible(MobEffectInstance instance, Operation<Boolean> original) {
@@ -375,6 +381,30 @@ public abstract class GuiInject implements GuiInjection {
             return kilt$yShift;
 
         return constant;
+    }
+
+    @WrapOperation(
+            method = "renderSelectedItemName",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/network/chat/MutableComponent;withStyle(Lnet/minecraft/ChatFormatting;)Lnet/minecraft/network/chat/MutableComponent;",
+                    ordinal = 0
+            ),
+            slice = @Slice(
+                    from = @At(
+                            value = "INVOKE",
+                            target = "Lnet/minecraft/world/item/ItemStack;getRarity()Lnet/minecraft/world/item/Rarity;"
+                    )
+            )
+    )
+    public MutableComponent kilt$applyCustomRarityStyle(
+            MutableComponent instance, ChatFormatting format, Operation<MutableComponent> original
+    ) {
+        var rarity = (RarityInjection) (Object) lastToolHighlight.getRarity();
+        if (rarity.kilt$isForge()) {
+            return instance.withStyle(rarity.getStyleModifier());
+        }
+        return original.call(instance, format);
     }
 
     // TODO: Debug text and FPS graph render, that should go into DebugScreenOverlay

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/item/ItemStackInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/item/ItemStackInject.java
@@ -4,20 +4,21 @@ package xyz.bluspring.kilt.forgeinjects.world.item;
 import com.bawnorton.mixinsquared.TargetHandler;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.state.BlockState;
@@ -32,12 +33,14 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import xyz.bluspring.kilt.helpers.mixin.CreateInitializer;
 import xyz.bluspring.kilt.helpers.mixin.Extends;
 import xyz.bluspring.kilt.injections.CapabilityProviderInjection;
 import xyz.bluspring.kilt.injections.item.ItemStackInjection;
+import xyz.bluspring.kilt.injections.world.item.RarityInjection;
 import xyz.bluspring.kilt.util.KiltHelper;
 
 import java.util.Objects;
@@ -62,6 +65,9 @@ public abstract class ItemStackInject implements IForgeItemStack, CapabilityProv
     @Shadow private int count;
     @Shadow public abstract Item getItem();
     @Shadow public abstract InteractionResult useOn(UseOnContext context);
+
+    @Shadow
+    public abstract Rarity getRarity();
 
     @Unique private boolean kilt$hasRunForgeInit = false;
 
@@ -242,6 +248,29 @@ public abstract class ItemStackInject implements IForgeItemStack, CapabilityProv
     @ModifyReturnValue(method = "getAttributeModifiers", at = @At("RETURN"))
     private Multimap<Attribute, AttributeModifier> kilt$invokeAttributeModifiersEvent(Multimap<Attribute, AttributeModifier> original, EquipmentSlot slot) {
         return HashMultimap.create(ForgeHooks.getAttributeModifiers((ItemStack) (Object) this, slot, original)); // Kilt: Make mutable, other mods depend on this.
+    }
+
+    @WrapOperation(
+            method = {"getTooltipLines", "getDisplayName"},
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/network/chat/MutableComponent;withStyle(Lnet/minecraft/ChatFormatting;)Lnet/minecraft/network/chat/MutableComponent;",
+                    ordinal = 0
+            ),
+            slice = @Slice(
+                    from = @At(
+                            value = "INVOKE",
+                            target = "Lnet/minecraft/world/item/ItemStack;getRarity()Lnet/minecraft/world/item/Rarity;"
+                    )
+            ),
+            require = 2
+    )
+    public MutableComponent kilt$applyCustomRarityStyle(MutableComponent instance, ChatFormatting format, Operation<MutableComponent> original) {
+        var rarity = (RarityInjection) (Object) getRarity();
+        if (rarity.kilt$isForge()) {
+            return instance.withStyle(rarity.getStyleModifier());
+        }
+        return original.call(instance, format);
     }
 
     @TargetHandler(mixin = "io.github.fabricators_of_create.porting_lib.tool.mixin.ItemStackMixin", name = "canPerformAction")

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/item/RarityInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/item/RarityInject.java
@@ -6,6 +6,7 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.world.item.Rarity;
 import net.minecraftforge.common.IExtensibleEnum;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -17,6 +18,9 @@ import java.util.function.UnaryOperator;
 @Mixin(Rarity.class)
 public class RarityInject implements RarityInjection, IExtensibleEnum {
     private UnaryOperator<Style> styleModifier;
+
+    @Unique
+    private boolean kilt$forge = false;
 
     @Inject(method = "<init>", at = @At("RETURN"))
     public void kilt$init(String string, int i, ChatFormatting color, CallbackInfo ci) {
@@ -41,5 +45,15 @@ public class RarityInject implements RarityInjection, IExtensibleEnum {
     @CreateStatic
     private static Rarity create(String name, UnaryOperator<Style> styleModifier) {
         return RarityInjection.create(name, styleModifier);
+    }
+
+    @Override
+    public boolean kilt$isForge() {
+        return kilt$forge;
+    }
+
+    @Override
+    public void kilt$setForge(boolean forge) {
+        this.kilt$forge = forge;
     }
 }

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/item/RarityInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/item/RarityInject.java
@@ -6,6 +6,9 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.world.item.Rarity;
 import net.minecraftforge.common.IExtensibleEnum;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.bluspring.kilt.helpers.mixin.CreateStatic;
 import xyz.bluspring.kilt.injections.world.item.RarityInjection;
 
@@ -14,6 +17,11 @@ import java.util.function.UnaryOperator;
 @Mixin(Rarity.class)
 public class RarityInject implements RarityInjection, IExtensibleEnum {
     private UnaryOperator<Style> styleModifier;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void kilt$init(String string, int i, ChatFormatting color, CallbackInfo ci) {
+        setStyleModifier((style) -> style.applyFormat(color));
+    }
 
     @Override
     public UnaryOperator<Style> getStyleModifier() {

--- a/src/main/java/xyz/bluspring/kilt/injections/world/item/RarityInjection.java
+++ b/src/main/java/xyz/bluspring/kilt/injections/world/item/RarityInjection.java
@@ -15,7 +15,6 @@ public interface RarityInjection {
                 name, (size) -> RarityAccessor.createRarity(name, size, formatting),
                 (values) -> RarityAccessor.setValues(values.toArray(new Rarity[0]))
         );
-        ((RarityInjection) (Object) value).setStyleModifier((style) -> style.applyFormat(formatting));
 
         return value;
     }

--- a/src/main/java/xyz/bluspring/kilt/injections/world/item/RarityInjection.java
+++ b/src/main/java/xyz/bluspring/kilt/injections/world/item/RarityInjection.java
@@ -15,6 +15,7 @@ public interface RarityInjection {
                 name, (size) -> RarityAccessor.createRarity(name, size, formatting),
                 (values) -> RarityAccessor.setValues(values.toArray(new Rarity[0]))
         );
+        ((RarityInjection) (Object) value).kilt$setForge(true);
 
         return value;
     }
@@ -24,6 +25,14 @@ public interface RarityInjection {
         ((RarityInjection) (Object) value).setStyleModifier(styleModifier);
 
         return value;
+    }
+
+    default boolean kilt$isForge() {
+        throw new IllegalStateException();
+    }
+
+    default void kilt$setForge(boolean forge) {
+        throw new IllegalStateException();
     }
 
     default UnaryOperator<Style> getStyleModifier() {


### PR DESCRIPTION
I was looking into an issue where JEI never started properly with Aether Redux and realised it was because the style modifier returned null for vanilla rarities, [causing a NullPointerException when receiving the recipe packet](https://github.com/Zepalesque/The-Aether-Redux/blob/1.20.1/src/main/java/net/zepalesque/redux/item/misc/LegacyBlockItem.java#L73).

But then I wanted to make sure it wouldn't break custom Fabric rarities and noticed that the style modifier never seemed to be used in Kilt, so I added the necessary injects to make them render as well. Since it's using `@WrapOperation` and only applies when the rarity is a "forge" rarity, I don't see this breaking any Fabric mods unless they still use `@Redirect` instead of `@WrapOperation`.