### PR TITLE
Use forge load order.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -479,9 +479,26 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
         }
     }
 
+    /**
+     * The natural order of Forge mods (if no dependencies are marked) is whichever order they get placed in a hash map.
+     * See: https://github.com/MinecraftForge/MinecraftForge/blob/1.20.1/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java#L42
+     * We want to use this order since some Forge mods might not declare their dependencies properly and just blindly rely on the default sorting.
+     */
+    fun getForgeNaturalOrder(): Comparator<ForgeMod> {
+        val modOrder = hashMapOf<String, Int>()
+        for (mod in this.mods) {
+            modOrder[mod.modId] = 0
+        }
+        var index = 0
+        for (modEntry in modOrder) {
+            modEntry.setValue(index++)
+        }
+        return Comparator.comparing { modOrder[it.modId] ?: 0 }
+    }
+
     override fun finishModScanning() {
         val graph = this.mods.buildGraph()
-        val sorted = TopologicalSort.topologicalSort(graph, null)
+        val sorted = TopologicalSort.topologicalSort(graph, getForgeNaturalOrder())
 
         // Sort the mods, otherwise stuff breaks.
         val modsRef = this.mods as MutableList<ForgeMod>

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -479,21 +479,20 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
         }
     }
 
+    // Copied from HashMap::hash
+    fun hash(key: Any?): Int {
+        val h: Int
+        return if (key == null) 0 else (key.hashCode().also { h = it }) xor (h ushr 16)
+    }
+
     /**
-     * The natural order of Forge mods (if no dependencies are marked) is whichever order they get placed in a hash map.
+     * Forge mods are sorted based on the order of keys in a hash map.
      * See: https://github.com/MinecraftForge/MinecraftForge/blob/1.20.1/fmlloader/src/main/java/net/minecraftforge/fml/loading/UniqueModListBuilder.java#L42
-     * We want to use this order since some Forge mods might not declare their dependencies properly and just blindly rely on the default sorting.
+     * This won't sort the mods in exactly the same order, but it will be close enough to hopefully resolve most issues caused by mods not explicitly denoting their dependencies.
+     * Users can always explicitly override this order with dependency overrides.
      */
     fun getForgeNaturalOrder(): Comparator<ForgeMod> {
-        val modOrder = hashMapOf<String, Int>()
-        for (mod in this.mods) {
-            modOrder[mod.modId] = 0
-        }
-        var index = 0
-        for (modEntry in modOrder) {
-            modEntry.setValue(index++)
-        }
-        return Comparator.comparing { modOrder[it.modId] ?: 0 }
+        return Comparator.comparing { hash(it.modId) }
     }
 
     override fun finishModScanning() {


### PR DESCRIPTION
Some Forge mods unfortunately rely on the default load order without explicitly declaring their dependencies.

On Forge, this order depends on the order of keys in a hash map, but at the very least it's always the same for a given modpack. On Kilt, the order is effectively random and changes every startup, which means it sometimes works and sometimes doesn't.

This patch changes that to make Kilt consistent with how Forge sorts the mods. Note that this won't mean that mods will be placed in the exact same order as they will on Forge every time. In fact, the main mod combination which motivated this change (Deep Aether + Lost Aether Content) doesn't work when only those mods are loaded in isolation because the hash map is a lot smaller with only those mods compared to how big it is without any other mods on Forge. However, it does work if you add more forge mods.