### PR TITLE
Fix some mixins being remapped when they shouldn't be.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -81,7 +81,7 @@ eventbus_version=6.2.17
 forgespi_version=7.1.3
 
 # custom fork - https://mvn.devos.one/#/snapshots/xyz/bluspring/AutoRenamingTool
-forgerenamer_version=0.1.52
+forgerenamer_version=0.1.53
 
 # custom fork - https://mvn.devos.one/#/snapshots/xyz/bluspring/srgutils
 srgutils_version = 0.5.15

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
@@ -415,8 +415,8 @@ object MixinRemapper {
                     for (methodOpt in currentClass.methods) {
                         val method = methodOpt.orElse(null) ?: continue
 
-                        val declaringClass = method.toString().replace("/" + method.name + method.descriptor, "")
-                        if (method.name == member && currentClass.name == declaringClass) {
+                        val declaringClass = method.declaringClass
+                        if (method.name == member && currentClass == declaringClass) {
                             // oh hey look, we found one
                             return "$mappedClassDescriptor${remapper.mapMethodName(target, method.name, method.descriptor)}${KiltRemapper.remapDescriptor(method.descriptor)}"
                         }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
@@ -54,7 +54,7 @@ object MixinRemapper {
             return annotationNode
         }
 
-        fun tryRemapMixinRefmap(value: String): String {
+        fun tryRemapMixinRefmap(value: String, isTarget: Boolean = true): String {
             // Do NOT remap this - this typically indicates MixinSquared or other extensions.
             if (value.startsWith("@"))
                 return value
@@ -64,13 +64,13 @@ object MixinRemapper {
                     return value
 
                 val original = mixinMapping[value]!!
-                val mapped = remapTargetString(original, classTargets, remapper)
+                val mapped = remapTargetString(original, classTargets, remapper, isTarget)
 
                 mixinMapping[value] = mapped
 
                 value
             } else {
-                val mapped = remapTargetString(value, classTargets, remapper)
+                val mapped = remapTargetString(value, classTargets, remapper, isTarget)
 
                 if (refmap != null) {
                     mixinMapping[value] = mapped
@@ -88,10 +88,10 @@ object MixinRemapper {
             val methodValue = values["method"]!!
 
             if (methodValue is String) {
-                values["method"] = tryRemapMixinRefmap(methodValue)
+                values["method"] = tryRemapMixinRefmap(methodValue, false)
             } else if (methodValue is List<*>) {
                 values["method"] = methodValue.map {
-                    tryRemapMixinRefmap(it as String)
+                    tryRemapMixinRefmap(it as String, false)
                 }
             }
         }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
@@ -280,7 +280,7 @@ object MixinRemapper {
     //      - pkg/to/ClassName.methodName(IL/other/descriptor/Stuff;)V // this is the cursed one.
     // however, some mods also completely disregard this format, so we have to keep that in mind.
     // i cannot remember what cursed formats they used though, is the problem....
-    fun remapTargetString(value: String, classTargets: Collection<String>, remapper: KiltEnhancedRemapper): String {
+    fun remapTargetString(value: String, classTargets: Collection<String>, remapper: KiltEnhancedRemapper, isTarget: Boolean = true): String {
         // Class reference, we can just return it directly.
         if (value.contains("/") && !value.startsWith("L") && !value.contains(";")) {
             return KiltRemapper.remapClass(value, ignoreWorkaround = true).breakpoint()
@@ -400,7 +400,27 @@ object MixinRemapper {
                         return "$mappedClassDescriptor$mappedName".breakpoint()
                 }
 
-                return KiltRemapper.srgMappedMethods[member]!!.values.first()
+                if (isTarget) {
+                    // If we're dealing with target methods, we can probably just use the first-name remap.
+                    return KiltRemapper.srgMappedMethods[member]!!.values.first()
+                }
+            }
+
+            if (!isTarget) {
+                // Can't really do first-name remaps safely here, we need to iterate through the class targets
+                // to figure out which method we *are* targeting.
+                for (target in classTargets) {
+                    val currentClass = remapper.getClass(target).orElse(null) ?: continue
+
+                    for (methodOpt in currentClass.methods) {
+                        val method = methodOpt.orElse(null) ?: continue
+
+                        if (method.name == member) {
+                            // oh hey look, we found one
+                            return "$mappedClassDescriptor${remapper.mapMethodName(target, method.name, method.descriptor)}${KiltRemapper.remapDescriptor(method.descriptor)}"
+                        }
+                    }
+                }
             }
         } else if (classDescriptor.isBlank()) {
             // If the class descriptor is blank, we're going to struggle to find any information we need, but we can still use some information to find stuff.

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
@@ -415,7 +415,8 @@ object MixinRemapper {
                     for (methodOpt in currentClass.methods) {
                         val method = methodOpt.orElse(null) ?: continue
 
-                        if (method.name == member) {
+                        val declaringClass = method.toString().replace("/" + method.name + method.descriptor, "")
+                        if (method.name == member && currentClass.name == declaringClass) {
                             // oh hey look, we found one
                             return "$mappedClassDescriptor${remapper.mapMethodName(target, method.name, method.descriptor)}${KiltRemapper.remapDescriptor(method.descriptor)}"
                         }


### PR DESCRIPTION
Note. This pull request depends on recent changes to [KiltMC/ForgeAutoRenamingTool](https://github.com/KiltMC/ForgeAutoRenamingTool). Please publish a new version of KiltMC/ForgeAutoRenamingTool before merging.

This pull request backports changes to the remapping fallback when the descriptor is unknown from 1.21.1 to 1.20.1.
However, it also changes it slightly so that it only remaps members if they are declared in the same class as the class target. This is in order to solve issues were certain mixins were being remapped when they shouldn't be, such as [ConfigBaseMixin::getWrap](https://github.com/jamesgreen26/ZeroPointSystems/blob/master/src/main/java/g_mungus/zps/mixin/ponder/ConfigBaseMixin.java#L18) in Zero Point Systems.

However, it is worth noting that there is a risk that this breaks some Forge mods that were previously working. All I know is that it works with all the mods I usually use and test with.