### PR TITLE
Make Genesis work

### DIFF
--- a/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidBuilderMixin.java
+++ b/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidBuilderMixin.java
@@ -139,7 +139,7 @@ public abstract class FluidBuilderMixin<T extends ForgeFlowingFluid, P> extends 
 
     @WrapMethod(method = "bucket()Lcom/tterrag/registrate/builders/ItemBuilder;")
     public ItemBuilder<BucketItem, FluidBuilder<?, P>> kilt$bucketFix(Operation<ItemBuilder<BucketItem, FluidBuilder<?, P>>> original) {
-        if (kilt$isForge) {
+        if (kilt$isForge) { // Needed to avoid a ClassCastException.
             NonNullBiFunction<? extends ForgeFlowingFluid, Item.Properties, BucketItem> function = BucketItem::new;
             //noinspection unchecked
             return bucket((NonNullBiFunction<? extends SimpleFlowableFluid, Item.Properties, BucketItem>) (Object) function);

--- a/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidBuilderMixin.java
+++ b/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidBuilderMixin.java
@@ -1,14 +1,12 @@
 package xyz.bluspring.kilt.compat.create.mixin.registrate_fabric;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.moulberry.mixinconstraints.annotations.IfModLoaded;
 import com.tterrag.registrate.AbstractRegistrate;
-import com.tterrag.registrate.builders.AbstractBuilder;
-import com.tterrag.registrate.builders.Builder;
-import com.tterrag.registrate.builders.BuilderCallback;
-import com.tterrag.registrate.builders.FluidBuilder;
+import com.tterrag.registrate.builders.*;
 import com.tterrag.registrate.fabric.SimpleFlowableFluid;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.util.entry.FluidEntry;
@@ -17,6 +15,8 @@ import com.tterrag.registrate.util.nullness.*;
 import net.minecraft.Util;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.BucketItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidType;
@@ -60,6 +60,10 @@ public abstract class FluidBuilderMixin<T extends ForgeFlowingFluid, P> extends 
     private NonNullSupplier<? extends SimpleFlowableFluid> source;
     @Mutable @Shadow @Final
     private List<TagKey<Fluid>> tags;
+
+    @Shadow
+    public abstract <I extends BucketItem> ItemBuilder<I, FluidBuilder<?, P>> bucket(NonNullBiFunction<? extends SimpleFlowableFluid, Item.Properties, ? extends I> factory);
+
     @Nullable
     private final NonNullSupplier<FluidType> fluidType;
     private NonNullConsumer<FluidType.Properties> typeProperties = NonNullConsumer.noop();
@@ -113,6 +117,42 @@ public abstract class FluidBuilderMixin<T extends ForgeFlowingFluid, P> extends 
 
         String bucketName = this.bucketName;
         this.kilt$fluidProperties = FluidBuilderHelper.createPropertiesConsumer(owner, name, bucketName);
+    }
+
+    @Intrinsic
+    public FluidBuilder<?, P> properties(NonNullConsumer<FluidType.Properties> cons) {
+        this.typeProperties = this.typeProperties.andThen(cons);
+        //noinspection unchecked
+        return (FluidBuilder<?, P>) (Object) this;
+    }
+
+    @WrapMethod(method = "fluidProperties")
+    public FluidBuilder<?, P> kilt$fluidProperties(NonNullConsumer<SimpleFlowableFluid.Properties> cons, Operation<FluidBuilder<?, P>> original) {
+        if (kilt$isForge) {
+            //noinspection unchecked
+            kilt$fluidProperties.andThen((NonNullConsumer<ForgeFlowingFluid.Properties>) (Object) cons);
+            //noinspection unchecked
+            return (FluidBuilder<?, P>) (Object) this;
+        }
+        return original.call(cons);
+    }
+
+    @WrapMethod(method = "bucket()Lcom/tterrag/registrate/builders/ItemBuilder;")
+    public ItemBuilder<BucketItem, FluidBuilder<?, P>> kilt$bucketFix(Operation<ItemBuilder<BucketItem, FluidBuilder<?, P>>> original) {
+        if (kilt$isForge) {
+            NonNullBiFunction<? extends ForgeFlowingFluid, Item.Properties, BucketItem> function = BucketItem::new;
+            //noinspection unchecked
+            return bucket((NonNullBiFunction<? extends SimpleFlowableFluid, Item.Properties, BucketItem>) (Object) function);
+        }
+        return original.call();
+    }
+
+    @WrapMethod(method = "lambda$bucket$11")
+    public BucketItem kilt$bucketLambdaFix(NonNullBiFunction factory, Item.Properties p, Operation<BucketItem> original) {
+        if (kilt$isForge) { // Needed to avoid a ClassCastException.
+            return (BucketItem) factory.apply(this.source.get(), p);
+        }
+        return original.call(factory, p);
     }
 
     @Inject(method = "<init>", at = @At("TAIL"))

--- a/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidEntryMixin.java
+++ b/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidEntryMixin.java
@@ -7,6 +7,8 @@ import com.tterrag.registrate.util.entry.FluidEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidType;
+import net.minecraftforge.fluids.ForgeFlowingFluid;
+import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
 
 @IfModLoaded("registrate-fabric")
@@ -19,5 +21,10 @@ public abstract class FluidEntryMixin extends RegistryEntry {
 
     public FluidType getType() {
         return ((Fluid) get()).forge$getFluidType();
+    }
+
+    @Intrinsic
+    public ForgeFlowingFluid getSource() {
+        return (ForgeFlowingFluid) ((ForgeFlowingFluid) get()).getSource();
     }
 }

--- a/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidEntryMixin.java
+++ b/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidEntryMixin.java
@@ -1,22 +1,43 @@
 package xyz.bluspring.kilt.compat.create.mixin.registrate_fabric;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.moulberry.mixinconstraints.annotations.IfModLoaded;
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.fabric.RegistryObject;
 import com.tterrag.registrate.util.entry.FluidEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import xyz.bluspring.kilt.Kilt;
+
+import java.util.Optional;
 
 @IfModLoaded("registrate-fabric")
 @SuppressWarnings("rawtypes")
 @Mixin(FluidEntry.class)
 public abstract class FluidEntryMixin extends RegistryEntry {
+
+    @Unique
+    private boolean kilt$isForge = false;
+
     public FluidEntryMixin(AbstractRegistrate<?> owner, RegistryObject delegate) {
         super(owner, delegate);
+    }
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void kilt$init(AbstractRegistrate owner, RegistryObject delegate, CallbackInfo ci) {
+        if (Kilt.Companion.getLoader().hasMod(owner.getModid())) {
+            kilt$isForge = true;
+        }
     }
 
     public FluidType getType() {
@@ -26,5 +47,13 @@ public abstract class FluidEntryMixin extends RegistryEntry {
     @Intrinsic
     public ForgeFlowingFluid getSource() {
         return (ForgeFlowingFluid) ((ForgeFlowingFluid) get()).getSource();
+    }
+
+    @WrapMethod(method = "getBucket")
+    public <I extends Item> Optional<I> kilt$getBucket(Operation<Optional<I>> original) {
+        if (kilt$isForge) {
+            return Optional.ofNullable((I) ((ForgeFlowingFluid) get()).getBucket());
+        }
+        return original.call();
     }
 }

--- a/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidEntryMixin.java
+++ b/compat/create-compat/src/main/java/xyz/bluspring/kilt/compat/create/mixin/registrate_fabric/FluidEntryMixin.java
@@ -51,7 +51,7 @@ public abstract class FluidEntryMixin extends RegistryEntry {
 
     @WrapMethod(method = "getBucket")
     public <I extends Item> Optional<I> kilt$getBucket(Operation<Optional<I>> original) {
-        if (kilt$isForge) {
+        if (kilt$isForge) { // Needed to avoid a ClassCastException.
             return Optional.ofNullable((I) ((ForgeFlowingFluid) get()).getBucket());
         }
         return original.call();

--- a/compat/fabric-compats/build.gradle.kts
+++ b/compat/fabric-compats/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     modCompileOnly("dev.architectury:architectury-fabric:${property("architectury_version")}")
 
     modCompileOnly("maven.modrinth:automodpack:${property("automodpack_version")}")
+    modCompileOnly("maven.modrinth:lodestonelib:${property("lodestone_version")}")
 }
 
 tasks {

--- a/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/lodestone/LodestoneShaderRegistryMixin.java
+++ b/compat/fabric-compats/src/main/java/xyz/bluspring/kilt/compat/fabric/mixin/lodestone/LodestoneShaderRegistryMixin.java
@@ -1,0 +1,32 @@
+package xyz.bluspring.kilt.compat.fabric.mixin.lodestone;
+
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
+import net.minecraft.server.packs.resources.ResourceProvider;
+import net.minecraftforge.client.event.RegisterShadersEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import team.lodestar.lodestone.LodestoneLib;
+import team.lodestar.lodestone.registry.client.LodestoneShaderRegistry;
+import team.lodestar.lodestone.systems.rendering.shader.ShaderHolder;
+import xyz.bluspring.kilt.helpers.mixin.CreateStatic;
+
+import java.io.IOException;
+
+@Pseudo
+@IfModLoaded("lodestone")
+@Mixin(LodestoneShaderRegistry.class)
+public class LodestoneShaderRegistryMixin {
+
+    // Copied from https://github.com/LodestarMC/Lodestone/blob/1.20/src/main/java/team/lodestar/lodestone/registry/client/LodestoneShaderRegistry.java#L55-L63
+    @CreateStatic
+    private static void registerShader(RegisterShadersEvent event, ShaderHolder shaderHolder) {
+        try {
+            ResourceProvider provider = event.getResourceProvider();
+            event.registerShader(shaderHolder.createInstance(provider), shaderHolder::setShaderInstance);
+        } catch (IOException e) {
+            LodestoneLib.LOGGER.error("Error registering shader", e);
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/compat/fabric-compats/src/main/resources/kilt_fabric_compats.mixins.json
+++ b/compat/fabric-compats/src/main/resources/kilt_fabric_compats.mixins.json
@@ -39,6 +39,7 @@
     "jei.FabricPluginFinderMixin",
     "jei.FluidStackMixin",
     "jei.TypedIngredientMixin",
+    "lodestone.LodestoneShaderRegistryMixin",
     "mkb.IKeyBindingMixin",
     "mkb.IKeyConflictContextMixin",
     "mkb.KeyConflictContextMixin",

--- a/compat/gradle.properties
+++ b/compat/gradle.properties
@@ -20,3 +20,5 @@ ldlib_version = mc1.20.1-1.0.40-forge
 littletiles_version = sBbUjEhq
 # https://modrinth.com/mod/creativecore/versions?g=1.20.1
 creativecore_version = HoxFnPO8
+# https://modrinth.com/mod/lodestonelib
+lodestone_version = 1.20.1-1.6.2.3f

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
@@ -264,6 +264,23 @@ object KiltMixinModifications {
     val MODIFY_VARIABLE = register(
         ModifyVariable::class.java,
 
+        // Fixes Genesis LevelRendererMixin
+        ReplacedAnnotationsModifier(
+            owner = "net/minecraft/client/renderer/LevelRenderer",
+            methods = listOf("renderSnowAndRain"),
+            variables = mapOf(
+                "at" to at("STORE", ordinal = 0),
+                "name" to listOf("f")
+            ),
+            replaceWith = listOf(
+                createAnnotation(ModifyVariable::class.java, mapOf(
+                    "method" to listOf("renderSnowAndRain"),
+                    "at" to at("STORE", ordinal = 0),
+                    "ordinal" to 1
+                ))
+            )
+        ),
+
         // Fixes the Aether's BossHealthOverlay
         ReplacedAnnotationsModifier(
             owner = "net/minecraft/client/gui/components/BossHealthOverlay",

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
@@ -343,6 +343,29 @@ object KiltMixinModifications {
     val WRAP_OPERATION = register(
         WrapOperation::class.java,
 
+        // Fix Genesis ServerLevelMixin
+        ReplacedAnnotationsModifier(
+            owner = "net/minecraft/server/level/ServerLevel",
+            methods = listOf("tick"),
+            variables = mapOf(
+                "at" to listOf(at(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/level/ServerLevel;getDayTime()J"
+                ))
+            ),
+            replaceWith = listOf(
+                createAnnotation(TargetHandler::class.java, mapOf(
+                    "mixin" to "xyz.bluspring.kilt.forgeinjects.server.level.ServerLevelInject",
+                    "name" to $$"kilt$useLevelDaytime",
+                    "prefix" to "redirect"
+                )),
+                createAnnotation(WrapOperation::class.java, mapOf(
+                    "method" to listOf("@MixinSquared:Handler"),
+                    "at" to listOf(at(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;getDayTime()J"))
+                ))
+            )
+        ),
+
         // Fixes Create's ProjectileUtilMixin
         ReplacedAnnotationsModifier(
             owner = "net/minecraft/world/entity/projectile/ProjectileUtil",


### PR DESCRIPTION
This pull request makes [Genesis](https://modrinth.com/mod/vs-genesis) work on Kilt (or well, it does most of the heavy lifting, #748 is also necessary since Zero Point Systems is a dependency of Genesis, but I wanted to merge that separately in case it needs to be reverted). Users will need to use the Fabric versions of Pekhui, Lodestone, Valkyrien Skies, VLib and Create.

The main thing is that there are 2 mixins that don't work without remapping. The first one ([ServerLevelMixin::useGenesisDayTime](https://github.com/jamesgreen26/genesis/blob/1.20.1/src/main/java/shipwrights/genesis/mixin/ServerLevelMixin.java#L44-L47)) is fairly straightforward because it's just targeting a Forge-patched method.
The second one ([LevelRendererMixin::modifyK2](https://github.com/jamesgreen26/genesis/blob/1.20.1/src/main/java/shipwrights/genesis/mixin/LevelRendererMixin.java#L18-L33)) is less ideal because a remapping wouldn't have been necessary if they just used `ordinal` instead of `name`, but I say we fix it because there might be someone who copy-pastes that mixin into another Forge mod.  
I also noticed Genesis likes to call a method which is only available in the Forge version of Lodestone ([LodestoneShaderRegistry::registerShader](https://github.com/LodestarMC/Lodestone/blob/1.20/src/main/java/team/lodestar/lodestone/registry/client/LodestoneShaderRegistry.java#L55-L63)), so I added that with  `@CreateStatic`.

After that the mod would have worked, but unfortunately they use Registrate, so I had to make some tweaks to the Registrate compatibility to make it work with Create Fabric. Most of it is just hacks to prevent it from casting miasma to SimpleFlowableFluid, but there were some missing methods and an existing one which needed special handling on Forge as well.