### PR TITLE
Added Kilt Dependency Overrides

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -60,7 +60,6 @@ import xyz.bluspring.knit.loader.mod.ModEnvironment
 import xyz.bluspring.knit.loader.mod.VersionConstraint
 import xyz.bluspring.knit.loader.util.*
 import java.nio.file.Path
-import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 import java.util.concurrent.ConcurrentHashMap
 import java.util.jar.JarFile
@@ -374,27 +373,25 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
             val dependencyOverrides = config.dependencyOverrides[modId]
 
             if (dependencyOverrides != null) {
-                val newDependencies = mutableMapOf<String, ModDependency>()
+                val modifiedDependencies = mutableMapOf<String, ModDependency>()
                 for (dep in dependencies) {
-                    newDependencies[dep.id] = dep
+                    modifiedDependencies[dep.id] = dep
                 }
                 for (dep in dependencyOverrides) {
-                    val prevDep = newDependencies[dep.key]
+                    val prevDep = modifiedDependencies[dep.key]
                     val additionalData = prevDep?.additionalData ?: mapOf()
-                    newDependencies[dep.key] = ModDependency(
+                    modifiedDependencies[dep.key] = ModDependency(
                         id = prevDep?.id ?: dep.key,
                         constraint = dep.value.version.map { ForgeVersionConstraint(it) as VersionConstraint }.orElse(prevDep?.constraint ?: ForgeVersionConstraint(VersionRange.createFromVersionSpec("(,1.0],[1.0,)"))),
                         type = dep.value.type.orElse(prevDep?.type ?: ModDependency.Type.OPTIONAL),
                         side = dep.value.side.orElse(prevDep?.side ?: ModEnvironment.BOTH),
-                        additionalData = if (dep.value.ordering.isPresent) {
-                            additionalData.plus(Pair("ordering", dep.value.ordering.get()))
-                        } else {
-                            additionalData
-                        }
+                        additionalData = dep.value.ordering.map {
+                            additionalData + ("ordering" to it)
+                        }.orElse(additionalData)
                     )
                 }
                 dependencies.clear()
-                dependencies.addAll(newDependencies.values)
+                dependencies.addAll(modifiedDependencies.values)
             }
 
             val definition = ModDefinition(

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -39,6 +39,7 @@ import net.minecraftforge.forgespi.language.MavenVersionAdapter
 import net.minecraftforge.forgespi.language.ModFileScanData
 import net.minecraftforge.forgespi.locating.ModFileFactory
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion
+import org.apache.maven.artifact.versioning.VersionRange
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.Type
 import thedarkcolour.kotlinforforge.KotlinModContainer
@@ -56,6 +57,7 @@ import xyz.bluspring.knit.loader.KnitModLoader
 import xyz.bluspring.knit.loader.mod.ModDefinition
 import xyz.bluspring.knit.loader.mod.ModDependency
 import xyz.bluspring.knit.loader.mod.ModEnvironment
+import xyz.bluspring.knit.loader.mod.VersionConstraint
 import xyz.bluspring.knit.loader.util.*
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -367,6 +369,32 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
                         "ordering" to IModInfo.Ordering.valueOf(forgeDep.getConfigElement<String>("ordering").orElse("NONE"))
                     )
                 ))
+            }
+
+            val dependencyOverrides = config.dependencyOverrides[modId]
+
+            if (dependencyOverrides != null) {
+                val newDependencies = mutableMapOf<String, ModDependency>()
+                for (dep in dependencies) {
+                    newDependencies[dep.id] = dep
+                }
+                for (dep in dependencyOverrides) {
+                    val prevDep = newDependencies[dep.key]
+                    val additionalData = prevDep?.additionalData ?: mapOf()
+                    newDependencies[dep.key] = ModDependency(
+                        id = prevDep?.id ?: dep.key,
+                        constraint = dep.value.version.map { ForgeVersionConstraint(it) as VersionConstraint }.orElse(prevDep?.constraint ?: ForgeVersionConstraint(VersionRange.createFromVersionSpec("(,1.0],[1.0,)"))),
+                        type = dep.value.type.orElse(prevDep?.type ?: ModDependency.Type.OPTIONAL),
+                        side = dep.value.side.orElse(prevDep?.side ?: ModEnvironment.BOTH),
+                        additionalData = if (dep.value.ordering.isPresent) {
+                            additionalData.plus(Pair("ordering", dep.value.ordering.get()))
+                        } else {
+                            additionalData
+                        }
+                    )
+                }
+                dependencies.clear()
+                dependencies.addAll(newDependencies.values)
             }
 
             val definition = ModDefinition(

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoaderConfig.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoaderConfig.kt
@@ -30,13 +30,14 @@ data class KiltLoaderConfig(
                 Codec.STRING.listOf()
                     .optionalFieldOf("force_disabled_mods", emptyList())
                     .forGetter(KiltLoaderConfig::forceDisabledModIds),
+                Codec.unboundedMap(
+                    Codec.STRING,
                     Codec.unboundedMap(
                         Codec.STRING,
-                        Codec.unboundedMap(
-                            Codec.STRING,
-                            ModDependencyOverride.CODEC
-                        )
-                    ).optionalFieldOf("dependency_overrides", emptyMap())
+                        ModDependencyOverride.CODEC
+                    )
+                )
+                    .optionalFieldOf("dependency_overrides", emptyMap())
                     .forGetter(KiltLoaderConfig::dependencyOverrides)
             )
                 .apply(instance, ::KiltLoaderConfig)
@@ -51,16 +52,21 @@ data class KiltLoaderConfig(
     ) {
         companion object {
             val VERSION_CONSTRAINT_CODEC: Codec<VersionRange> = Codec.STRING.xmap(
-                { VersionRange.createFromVersionSpec(it) },
-                {it.toString()}
+                VersionRange::createFromVersionSpec,
+                VersionRange::toString
             )
             val CODEC: Codec<ModDependencyOverride> = RecordCodecBuilder.create { instance ->
                 instance.group(
-                    VERSION_CONSTRAINT_CODEC.optionalFieldOf("version").forGetter { it.version },
-                    EnumUtils.createThrowingFallbackCodec<Type>().optionalFieldOf("type").forGetter { it.type },
-                    EnumUtils.createThrowingFallbackCodec<ModEnvironment>().optionalFieldOf("side").forGetter { it.side },
-                    EnumUtils.createThrowingFallbackCodec<IModInfo.Ordering>().optionalFieldOf("ordering").forGetter { it.ordering }
-                ).apply(instance, ::ModDependencyOverride)
+                    VERSION_CONSTRAINT_CODEC.optionalFieldOf("version")
+                        .forGetter(ModDependencyOverride::version),
+                    EnumUtils.createThrowingFallbackCodec<Type>().optionalFieldOf("type")
+                        .forGetter(ModDependencyOverride::type),
+                    EnumUtils.createThrowingFallbackCodec<ModEnvironment>().optionalFieldOf("side")
+                        .forGetter(ModDependencyOverride::side),
+                    EnumUtils.createThrowingFallbackCodec<IModInfo.Ordering>().optionalFieldOf("ordering")
+                        .forGetter(ModDependencyOverride::ordering)
+                )
+                    .apply(instance, ::ModDependencyOverride)
             }
         }
     }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoaderConfig.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoaderConfig.kt
@@ -3,14 +3,25 @@ package xyz.bluspring.kilt.loader
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.fabricmc.loader.api.FabricLoader
+import net.minecraftforge.forgespi.language.IModInfo
+import org.apache.maven.artifact.versioning.VersionRange
+import xyz.bluspring.kilt.util.EnumUtils
+import xyz.bluspring.knit.loader.mod.ModDependency.Type
+import xyz.bluspring.knit.loader.mod.ModEnvironment
 import java.nio.file.Path
+import java.util.Optional
 
 @JvmRecord
 data class KiltLoaderConfig(
     /**
      * Represents the list of mod IDs that should not be getting resolved by Kilt.
      */
-    val forceDisabledModIds: List<String> = emptyList()
+    val forceDisabledModIds: List<String> = emptyList(),
+
+    /**
+     * Dependency overrides, a Kilt alternative to https://wiki.fabricmc.net/tutorial:dependency_overrides
+     */
+    val dependencyOverrides: Map<String, Map<String, ModDependencyOverride>> = emptyMap()
 ) {
     companion object {
         val PATH: Path = FabricLoader.getInstance().configDir.resolve("kilt_overrides.json")
@@ -18,9 +29,39 @@ data class KiltLoaderConfig(
             instance.group(
                 Codec.STRING.listOf()
                     .optionalFieldOf("force_disabled_mods", emptyList())
-                    .forGetter(KiltLoaderConfig::forceDisabledModIds)
+                    .forGetter(KiltLoaderConfig::forceDisabledModIds),
+                    Codec.unboundedMap(
+                        Codec.STRING,
+                        Codec.unboundedMap(
+                            Codec.STRING,
+                            ModDependencyOverride.CODEC
+                        )
+                    ).optionalFieldOf("dependency_overrides", emptyMap())
+                    .forGetter(KiltLoaderConfig::dependencyOverrides)
             )
                 .apply(instance, ::KiltLoaderConfig)
+        }
+    }
+
+    data class ModDependencyOverride(
+        val version: Optional<VersionRange> = Optional.empty(),
+        val type: Optional<Type> = Optional.empty(),
+        val side: Optional<ModEnvironment> = Optional.empty(),
+        val ordering: Optional<IModInfo.Ordering> = Optional.empty()
+    ) {
+        companion object {
+            val VERSION_CONSTRAINT_CODEC: Codec<VersionRange> = Codec.STRING.xmap(
+                { VersionRange.createFromVersionSpec(it) },
+                {it.toString()}
+            )
+            val CODEC: Codec<ModDependencyOverride> = RecordCodecBuilder.create { instance ->
+                instance.group(
+                    VERSION_CONSTRAINT_CODEC.optionalFieldOf("version").forGetter { it.version },
+                    EnumUtils.createThrowingFallbackCodec<Type>().optionalFieldOf("type").forGetter { it.type },
+                    EnumUtils.createThrowingFallbackCodec<ModEnvironment>().optionalFieldOf("side").forGetter { it.side },
+                    EnumUtils.createThrowingFallbackCodec<IModInfo.Ordering>().optionalFieldOf("ordering").forGetter { it.ordering }
+                ).apply(instance, ::ModDependencyOverride)
+            }
         }
     }
 }

--- a/src/main/kotlin/xyz/bluspring/kilt/util/EnumUtils.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/EnumUtils.kt
@@ -2,10 +2,13 @@ package xyz.bluspring.kilt.util
 
 import com.chocohead.mm.CasualStreamHandler
 import com.chocohead.mm.api.ClassTinkerers
+import com.mojang.serialization.Codec
 import net.minecraftforge.common.IExtensibleEnum
 import net.minecraftforge.fml.unsafe.UnsafeHacks
 import xyz.bluspring.kilt.Kilt
+import java.util.Locale.getDefault
 import java.util.function.Consumer
+import kotlin.text.uppercase
 
 object EnumUtils {
     @JvmStatic
@@ -47,6 +50,21 @@ object EnumUtils {
             Kilt.logger.error("Failed to dynamically load class $name!")
             e.printStackTrace()
             null
+        }
+    }
+
+    @JvmStatic
+    inline fun <reified T : Enum<T>> createThrowingFallbackCodec(ignoreCase: Boolean = true): Codec<T> {
+        return if (ignoreCase) {
+            Codec.STRING.xmap(
+                { enumValueOf<T>(it.uppercase()) },
+                { it.name.lowercase(getDefault()) }
+            )
+        } else {
+            Codec.STRING.xmap(
+                { enumValueOf<T>(it) },
+                { it.name }
+            )
         }
     }
 }


### PR DESCRIPTION
This PR adds a new option to the `kilt_overrides.json` config file: `dependency_overrides`.
It is more or less equivalent to [Fabric Dependency Overrides](https://wiki.fabricmc.net/tutorial:dependency_overrides), but also allows the user to change the dependency ordering.

At the moment, it allows the user to override the `version` (which overrides the constraint field, I felt "version" would be more readable to the user), `type` (optional vs required, but supports incompatible and discouraged as well), `side` (client, server or both) and `ordering` (before, after or none). All fields are optional and will only replace the mod's builtin definition if specified. If no builtin dependency definition is found it default to any version, optional type, both sides and none ordering respectively when a field is unspecified.

One thing worth noting is that it does not include a way to remove the dependency definitions from mods, but simply overriding `type` to `optional` should accomplish the same thing (as well as maybe setting `ordering` to `none` if necessary).

Also, the enum codecs throw an exception when parsing an invalid name. This is by design to help modpack makers find spelling mistakes more quickly.