### PR TITLE
Should probably mark environments on both sides as BOTH instead of SERVER.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -343,7 +343,7 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
                     side = when (neoDep.getConfigElement<String>("side").orElse("BOTH")) {
                         "CLIENT" -> ModEnvironment.CLIENT
                         "SERVER" -> ModEnvironment.SERVER
-                        "BOTH" -> ModEnvironment.SERVER
+                        "BOTH" -> ModEnvironment.BOTH
                         else -> throw IllegalArgumentException("Invalid side ${neoDep.getConfigElement<String>("side")} provided while handling Forge mod file $fileName!")
                     },
 


### PR DESCRIPTION
This is the 1.21.1 version. Cherry picking caused a bunch of merge conflicts.