### PR TITLE
Forcefully re-inject the unmapped component setters lost at compile time.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/mixin/workarounds/MutableDataComponentHolderMixin.java
+++ b/src/main/java/xyz/bluspring/kilt/mixin/workarounds/MutableDataComponentHolderMixin.java
@@ -1,0 +1,69 @@
+package xyz.bluspring.kilt.mixin.workarounds;
+
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponentType;
+import net.neoforged.neoforge.common.MutableDataComponentHolder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.*;
+import xyz.bluspring.kilt.workarounds.MutableDataComponentHolderWorkaround;
+
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
+
+@Implements(@Interface(iface = MutableDataComponentHolderWorkaround.class, prefix = "kilt$i$", remap = Interface.Remap.NONE))
+@Mixin(MutableDataComponentHolder.class)
+public interface MutableDataComponentHolderMixin {
+
+    @Shadow
+    @Nullable
+    <T> T set(DataComponentType<? super T> dataComponentType, @Nullable T object);
+
+    @Shadow
+    @Nullable <T, U> T update(DataComponentType<T> componentType, T value, U updateContext, BiFunction<T, U, T> updater);
+
+    @Shadow
+    @Nullable <T> T update(DataComponentType<T> componentType, T value, UnaryOperator<T> updater);
+
+    @Shadow
+    @Nullable
+    <T> T remove(DataComponentType<? extends T> dataComponentType);
+
+    @Shadow
+    void applyComponents(DataComponentPatch patch);
+
+    @Shadow
+    void applyComponents(DataComponentMap dataComponentMap);
+
+    @Intrinsic
+    default <T> T kilt$i$set(@NotNull DataComponentType<? super T> componentType, @Nullable T value) {
+        return this.set(componentType, value);
+    }
+
+    @Intrinsic
+    default <T> T kilt$i$remove(@NotNull DataComponentType<? super T> componentType) {
+        //noinspection unchecked
+        return this.remove((DataComponentType<? extends T>) componentType);
+    }
+
+    @Intrinsic
+    default <T, U> T kilt$i$update(DataComponentType<T> componentType, T value, U updateContext, BiFunction<T, U, T> updater) {
+        return this.update(componentType, value, updateContext, updater);
+    }
+
+    @Intrinsic
+    default <T> T kilt$i$update(DataComponentType<T> componentType, T value, UnaryOperator<T> updater) {
+        return this.update(componentType, value, updater);
+    }
+
+    @Intrinsic
+    default void kilt$i$applyComponents(@NotNull DataComponentPatch patch) {
+        this.applyComponents(patch);
+    }
+
+    @Intrinsic
+    default void kilt$i$applyComponents(@NotNull DataComponentMap components) {
+        this.applyComponents(components);
+    }
+}

--- a/src/main/java/xyz/bluspring/kilt/workarounds/MutableDataComponentHolderWorkaround.java
+++ b/src/main/java/xyz/bluspring/kilt/workarounds/MutableDataComponentHolderWorkaround.java
@@ -1,0 +1,25 @@
+package xyz.bluspring.kilt.workarounds;
+
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponentType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
+
+public interface MutableDataComponentHolderWorkaround {
+
+    <T> T set(@NotNull DataComponentType<? super T> componentType, @Nullable T value);
+
+    <T, U> T update(DataComponentType<T> componentType, T value, U updateContext, BiFunction<T, U, T> updater);
+
+    <T> T update(DataComponentType<T> componentType, T value, UnaryOperator<T> updater);
+
+    <T> T remove(@NotNull DataComponentType<? super T> componentType);
+
+    void applyComponents(@NotNull DataComponentPatch patch);
+
+    void applyComponents(@NotNull DataComponentMap components);
+}

--- a/src/main/resources/Kilt.mixins.json
+++ b/src/main/resources/Kilt.mixins.json
@@ -80,6 +80,7 @@
     "resources.RegistryOpsAccessor",
     "server.level.TicketAccessor",
     "workarounds.ICommonPacketListenerMixin",
+    "workarounds.MutableDataComponentHolderMixin",
     "workarounds.ServerCommonPacketListenerImplMixin",
     "workarounds.ServerConfigurationPacketListenerMixin",
     "world.inventory.GrindstoneMenuAccessor",


### PR DESCRIPTION
A few of the methods in MutableDataComponentHolder are remapped to the intermediary method in ItemStack of the same name when Kilt is compiled. This is undesirable, so this pull request re-adds the non-remapped ones with a mixin, allowing Forge mods to target them properly again.