### PR TITLE
Add the Kilt Overrides config file from 1.20.1

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -39,6 +39,7 @@ import net.neoforged.neoforgespi.language.IModInfo
 import net.neoforged.neoforgespi.language.MavenVersionAdapter
 import net.neoforged.neoforgespi.language.ModFileScanData
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion
+import org.apache.maven.artifact.versioning.VersionRange
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.Type
 import xyz.bluspring.kilt.Kilt
@@ -58,6 +59,7 @@ import xyz.bluspring.knit.loader.KnitModLoader
 import xyz.bluspring.knit.loader.mod.ModDefinition
 import xyz.bluspring.knit.loader.mod.ModDependency
 import xyz.bluspring.knit.loader.mod.ModEnvironment
+import xyz.bluspring.knit.loader.mod.VersionConstraint
 import xyz.bluspring.knit.loader.util.*
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
@@ -386,6 +388,30 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
                 mixinConfigs.add(ModDefinition.MixinConfig(
                     mixinConfig.getConfigElement<String>("config").orElse(null) ?: continue
                 ))
+            }
+
+            val dependencyOverrides = config.dependencyOverrides[modId]
+
+            if (dependencyOverrides != null) {
+                val modifiedDependencies = mutableMapOf<String, ModDependency>()
+                for (dep in dependencies) {
+                    modifiedDependencies[dep.id] = dep
+                }
+                for (dep in dependencyOverrides) {
+                    val prevDep = modifiedDependencies[dep.key]
+                    val additionalData = prevDep?.additionalData ?: mapOf()
+                    modifiedDependencies[dep.key] = ModDependency(
+                        id = prevDep?.id ?: dep.key,
+                        constraint = dep.value.version.map { NeoForgeVersionConstraint(it) as VersionConstraint }.orElse(prevDep?.constraint ?: NeoForgeVersionConstraint(VersionRange.createFromVersionSpec("(,1.0],[1.0,)"))),
+                        type = dep.value.type.orElse(prevDep?.type ?: ModDependency.Type.OPTIONAL),
+                        side = dep.value.side.orElse(prevDep?.side ?: ModEnvironment.BOTH),
+                        additionalData = dep.value.ordering.map {
+                            additionalData + ("ordering" to it)
+                        }.orElse(additionalData)
+                    )
+                }
+                dependencies.clear()
+                dependencies.addAll(modifiedDependencies.values)
             }
 
             val definition = ModDefinition(

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -399,7 +399,7 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
                 }
                 for (dep in dependencyOverrides) {
                     val prevDep = modifiedDependencies[dep.key]
-                    val additionalData = prevDep?.additionalData ?: mapOf()
+                    val additionalData = prevDep?.additionalData ?: mapOf("ordering" to IModInfo.Ordering.NONE)
                     modifiedDependencies[dep.key] = ModDependency(
                         id = prevDep?.id ?: dep.key,
                         constraint = dep.value.version.map { NeoForgeVersionConstraint(it) as VersionConstraint }.orElse(prevDep?.constraint ?: NeoForgeVersionConstraint(VersionRange.createFromVersionSpec("(,1.0],[1.0,)"))),

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -3,6 +3,7 @@ package xyz.bluspring.kilt.loader
 import com.electronwill.nightconfig.core.CommentedConfig
 import com.electronwill.nightconfig.toml.TomlParser
 import com.google.gson.JsonParser
+import com.mojang.serialization.JsonOps
 import cpw.mods.modlauncher.Launcher
 import cpw.mods.modlauncher.api.IEnvironment
 import cpw.mods.niofs.union.KiltUnionFileSystemHelper
@@ -59,6 +60,7 @@ import xyz.bluspring.knit.loader.mod.ModDependency
 import xyz.bluspring.knit.loader.mod.ModEnvironment
 import xyz.bluspring.knit.loader.util.*
 import java.nio.file.Path
+import java.nio.file.StandardOpenOption
 import java.util.concurrent.ConcurrentHashMap
 import java.util.jar.JarFile
 import java.util.jar.Manifest
@@ -69,6 +71,7 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
     private val loadedModIds = mutableSetOf<String>()
 
     private val environment = KiltEnvironment()
+    var config = KiltLoaderConfig()
 
     // At this point, this is a wall of shame for mods that bundle both Forge and Fabric as one JAR, but don't actually
     // use the same mod ID.
@@ -108,6 +111,21 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
             if (path.isPresent && path.orElseThrow().isDirectory()) {
                 Kilt.logger.warn("Kilt: Fabric mod ${container.metadata.name} (${container.metadata.id}) is likely repackaging NeoForge classes! This may lead to a game crash!")
             }
+        }
+
+        this.loadConfig()
+    }
+
+    fun loadConfig() {
+        if (KiltLoaderConfig.PATH.exists()) {
+            KiltLoaderConfig.CODEC.decode(JsonOps.INSTANCE, JsonParser.parseReader(KiltLoaderConfig.PATH.reader(options = arrayOf(StandardOpenOption.READ))))
+                .resultOrPartial()
+                .map { it.first }
+                .ifPresentOrElse({
+                    this.config = it
+                }) {
+                    Kilt.logger.error("Failed to load config!")
+                }
         }
     }
 
@@ -293,6 +311,11 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
             // mods should really use the same mod ID between their mods >:(
             if (SKIPPED_FABRIC_MODS.contains(modId)) {
                 Kilt.logger.warn("Mod ID $modId is a combined mod JAR already existing under ID ${SKIPPED_FABRIC_MODS[modId]}, skipping!")
+                continue
+            }
+
+            if (this.config.forceDisabledModIds.contains(modId)) {
+                Kilt.logger.info("Mod ID $modId was detected to be forcefully disabled in the config, skipping.")
                 continue
             }
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoaderConfig.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoaderConfig.kt
@@ -1,0 +1,26 @@
+package xyz.bluspring.kilt.loader
+
+import com.mojang.serialization.Codec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.fabricmc.loader.api.FabricLoader
+import java.nio.file.Path
+
+@JvmRecord
+data class KiltLoaderConfig(
+    /**
+     * Represents the list of mod IDs that should not be getting resolved by Kilt.
+     */
+    val forceDisabledModIds: List<String> = emptyList()
+) {
+    companion object {
+        val PATH: Path = FabricLoader.getInstance().configDir.resolve("kilt_overrides.json")
+        val CODEC: Codec<KiltLoaderConfig> = RecordCodecBuilder.create { instance ->
+            instance.group(
+                Codec.STRING.listOf()
+                    .optionalFieldOf("force_disabled_mods", emptyList())
+                    .forGetter(KiltLoaderConfig::forceDisabledModIds)
+            )
+                .apply(instance, ::KiltLoaderConfig)
+        }
+    }
+}

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoaderConfig.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoaderConfig.kt
@@ -3,14 +3,25 @@ package xyz.bluspring.kilt.loader
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.fabricmc.loader.api.FabricLoader
+import net.neoforged.neoforgespi.language.IModInfo
+import org.apache.maven.artifact.versioning.VersionRange
+import xyz.bluspring.kilt.util.EnumUtils
+import xyz.bluspring.knit.loader.mod.ModDependency.Type
+import xyz.bluspring.knit.loader.mod.ModEnvironment
 import java.nio.file.Path
+import java.util.Optional
 
 @JvmRecord
 data class KiltLoaderConfig(
     /**
      * Represents the list of mod IDs that should not be getting resolved by Kilt.
      */
-    val forceDisabledModIds: List<String> = emptyList()
+    val forceDisabledModIds: List<String> = emptyList(),
+
+    /**
+     * Dependency overrides, a Kilt alternative to https://wiki.fabricmc.net/tutorial:dependency_overrides
+     */
+    val dependencyOverrides: Map<String, Map<String, ModDependencyOverride>> = emptyMap()
 ) {
     companion object {
         val PATH: Path = FabricLoader.getInstance().configDir.resolve("kilt_overrides.json")
@@ -18,9 +29,45 @@ data class KiltLoaderConfig(
             instance.group(
                 Codec.STRING.listOf()
                     .optionalFieldOf("force_disabled_mods", emptyList())
-                    .forGetter(KiltLoaderConfig::forceDisabledModIds)
+                    .forGetter(KiltLoaderConfig::forceDisabledModIds),
+                Codec.unboundedMap(
+                    Codec.STRING,
+                    Codec.unboundedMap(
+                        Codec.STRING,
+                        ModDependencyOverride.CODEC
+                    )
+                )
+                    .optionalFieldOf("dependency_overrides", emptyMap())
+                    .forGetter(KiltLoaderConfig::dependencyOverrides)
             )
                 .apply(instance, ::KiltLoaderConfig)
+        }
+    }
+
+    data class ModDependencyOverride(
+        val version: Optional<VersionRange> = Optional.empty(),
+        val type: Optional<Type> = Optional.empty(),
+        val side: Optional<ModEnvironment> = Optional.empty(),
+        val ordering: Optional<IModInfo.Ordering> = Optional.empty()
+    ) {
+        companion object {
+            val VERSION_CONSTRAINT_CODEC: Codec<VersionRange> = Codec.STRING.xmap(
+                VersionRange::createFromVersionSpec,
+                VersionRange::toString
+            )
+            val CODEC: Codec<ModDependencyOverride> = RecordCodecBuilder.create { instance ->
+                instance.group(
+                    VERSION_CONSTRAINT_CODEC.optionalFieldOf("version")
+                        .forGetter(ModDependencyOverride::version),
+                    EnumUtils.createThrowingFallbackCodec<Type>().optionalFieldOf("type")
+                        .forGetter(ModDependencyOverride::type),
+                    EnumUtils.createThrowingFallbackCodec<ModEnvironment>().optionalFieldOf("side")
+                        .forGetter(ModDependencyOverride::side),
+                    EnumUtils.createThrowingFallbackCodec<IModInfo.Ordering>().optionalFieldOf("ordering")
+                        .forGetter(ModDependencyOverride::ordering)
+                )
+                    .apply(instance, ::ModDependencyOverride)
+            }
         }
     }
 }

--- a/src/main/kotlin/xyz/bluspring/kilt/util/EnumUtils.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/EnumUtils.kt
@@ -2,10 +2,13 @@ package xyz.bluspring.kilt.util
 
 import com.chocohead.mm.CasualStreamHandler
 import com.chocohead.mm.api.ClassTinkerers
+import com.mojang.serialization.Codec
 import net.minecraftforge.fml.unsafe.UnsafeHacks
 import net.neoforged.fml.common.asm.enumextension.IExtensibleEnum
 import xyz.bluspring.kilt.Kilt
+import java.util.Locale.getDefault
 import java.util.function.Consumer
+import kotlin.text.uppercase
 
 object EnumUtils {
     @JvmStatic
@@ -47,6 +50,21 @@ object EnumUtils {
             Kilt.logger.error("Failed to dynamically load class $name!")
             e.printStackTrace()
             null
+        }
+    }
+
+    @JvmStatic
+    inline fun <reified T : Enum<T>> createThrowingFallbackCodec(ignoreCase: Boolean = true): Codec<T> {
+        return if (ignoreCase) {
+            Codec.STRING.xmap(
+                { enumValueOf<T>(it.uppercase()) },
+                { it.name.lowercase(getDefault()) }
+            )
+        } else {
+            Codec.STRING.xmap(
+                { enumValueOf<T>(it) },
+                { it.name }
+            )
         }
     }
 }


### PR DESCRIPTION
I was planning to port #765 to 1.21.1, but then I realised that the config file wasn't there.
So this PR adds the config file with both `force_disabled_mods` and `dependency_overrides`.