### PR TITLE
Fix seeds not placeable on rich soil in Farmer's Delight Refabricated.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/level/block/BushBlockInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/level/block/BushBlockInject.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import xyz.bluspring.kilt.util.KiltHelper;
 
-@Mixin(value = BushBlock.class, priority = 950)
+@Mixin(BushBlock.class)
 public abstract class BushBlockInject extends Block implements IPlantable {
     public BushBlockInject(Properties properties) {
         super(properties);

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/level/block/BushBlockInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/level/block/BushBlockInject.java
@@ -1,30 +1,37 @@
 // TRACKED HASH: d335200a23b4a1e738aa9a7ea4e390f5f72a6c5d
 package xyz.bluspring.kilt.forgeinjects.world.level.block;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.BushBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.IPlantable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(BushBlock.class)
+@Mixin(value = BushBlock.class, priority = 950)
 public abstract class BushBlockInject extends Block implements IPlantable {
     public BushBlockInject(Properties properties) {
         super(properties);
     }
 
-    @Inject(method = "canSurvive", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/BushBlock;mayPlaceOn(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z"), cancellable = true)
-    private void kilt$checkCanSustain(BlockState state, LevelReader level, BlockPos pos, CallbackInfoReturnable<Boolean> cir, @Local(ordinal = 1) BlockPos pos2) {
+    @WrapOperation(
+            method = "canSurvive",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/BushBlock;mayPlaceOn(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z")
+    )
+    private boolean kilt$checkCanSustain(
+            BushBlock instance, BlockState stateAtPos, BlockGetter level, BlockPos posBelow, Operation<Boolean> original,
+            @Local(argsOnly = true) BlockState state
+    ) {
         if (state.getBlock() == this) {
-            cir.setReturnValue(level.getBlockState(pos2).canSustainPlant(level, pos2, Direction.UP, this));
+            return stateAtPos.canSustainPlant(level, posBelow, Direction.UP, this);
         }
+        return original.call(instance, stateAtPos, level, posBelow);
     }
 
     // Kilt: handled by Porting Lib

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/level/block/BushBlockInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/level/block/BushBlockInject.java
@@ -13,6 +13,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.IPlantable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import xyz.bluspring.kilt.util.KiltHelper;
 
 @Mixin(value = BushBlock.class, priority = 950)
 public abstract class BushBlockInject extends Block implements IPlantable {
@@ -25,13 +26,19 @@ public abstract class BushBlockInject extends Block implements IPlantable {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/BushBlock;mayPlaceOn(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z")
     )
     private boolean kilt$checkCanSustain(
-            BushBlock instance, BlockState stateAtPos, BlockGetter level, BlockPos posBelow, Operation<Boolean> original,
+            BushBlock instance, BlockState stateBelow, BlockGetter level, BlockPos posBelow, Operation<Boolean> original,
             @Local(argsOnly = true) BlockState state
     ) {
-        if (state.getBlock() == this) {
-            return stateAtPos.canSustainPlant(level, posBelow, Direction.UP, this);
+        if (
+                state.getBlock() == this &&
+                KiltHelper.INSTANCE.hasMethodOverride(
+                        stateBelow.getBlock().getClass(), Block.class, "canSustainPlant",
+                        BlockState.class, BlockGetter.class, BlockPos.class, Direction.class, IPlantable.class
+                )
+        ) {
+            return stateBelow.canSustainPlant(level, posBelow, Direction.UP, this);
         }
-        return original.call(instance, stateAtPos, level, posBelow);
+        return original.call(instance, stateBelow, level, posBelow);
     }
 
     // Kilt: handled by Porting Lib


### PR DESCRIPTION
Rewrites BushBlockInject to allow Fabric mods (such as Farmer's Delight Refabricated) to change the return value. I set the priority to 950 as well to make sure Fabric mods that use `@WrapOperation` around `mayPlaceOn` should wrap around this mixin.

This should still work with the Forge version of Farmer's Delight.