### PR TITLE
Enum Extension Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -223,7 +223,7 @@ allprojects {
             implementation("com.github.FabricCompatibilityLayers.CursedMixinExtensions:CursedMixinExtensions:${rootProject.property("cursedmixinextensions_version")}") {
                 exclude("org.ow2.asm")
             }
-            modImplementation("com.github.Chocohead:Fabric-ASM:v${rootProject.property("fabric_asm_version")}")
+            modImplementation("xyz.bluspring.fork:Fabric-ASM:${rootProject.property("fabric_asm_version")}")
             implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${rootProject.property("mixin_squared_version")}") {
                 exclude("org.ow2.asm")
             })
@@ -244,7 +244,7 @@ dependencies {
     // JiJ'd into main JAR alone
     //include("io.github.llamalad7:mixinextras-fabric:${property("mixinextras_version")}")
     include("com.github.FabricCompatibilityLayers.CursedMixinExtensions:CursedMixinExtensions:${property("cursedmixinextensions_version")}")
-    include("com.github.Chocohead:Fabric-ASM:v${property("fabric_asm_version")}")
+    include("xyz.bluspring.fork:Fabric-ASM:${property("fabric_asm_version")}")
     include("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${rootProject.property("mixin_squared_version")}")
     include("de.florianreuth:asmfabricloader:${property("asmfabricloader_version")}")
     include("com.moulberry:mixinconstraints:${rootProject.property("mixinconstraints_version")}") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,8 +43,8 @@ cursedmixinextensions_version=1.1.0
 # https://github.com/LlamaLad7/MixinExtras/releases
 mixinextras_version=0.5.0
 
-# https://github.com/Chocohead/Fabric-ASM/blob/master/build.gradle#L29
-fabric_asm_version=2.3
+# https://github.com/KiltMC/Fabric-ASM
+fabric_asm_version=2.4
 
 # https://github.com/Bawnorton/MixinSquared/releases
 mixin_squared_version=0.3.3

--- a/src/main/java/xyz/bluspring/kilt/KiltMixinPlugin.java
+++ b/src/main/java/xyz/bluspring/kilt/KiltMixinPlugin.java
@@ -17,6 +17,7 @@ import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import xyz.bluspring.kilt.helpers.mixin.MixinExtensionHelper;
+import xyz.bluspring.kilt.loader.asm.EnumExtensionLoader;
 import xyz.bluspring.kilt.loader.mixin.modifications.KiltMixinModifier;
 
 import java.util.List;
@@ -96,11 +97,13 @@ public class KiltMixinPlugin implements IMixinConfigPlugin {
     @Override
     public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
         MixinExtensionHelper.preApply(targetClassName, targetClass, mixinClassName, mixinInfo);
+        EnumExtensionLoader.INSTANCE.preApplyEnum(targetClass, mixinInfo.getClassNode(0));
     }
 
     @Override
     public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
         MixinExtensionHelper.postApply(targetClassName, targetClass, mixinClassName, mixinInfo);
+        EnumExtensionLoader.INSTANCE.postApplyEnum(targetClass, mixinInfo.getClassNode(0));
         CursedMixinExtensions.postApply(targetClass);
     }
 }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -45,6 +45,7 @@ import org.objectweb.asm.Type
 import xyz.bluspring.kilt.Kilt
 import xyz.bluspring.kilt.api.compatibility.KiltModCompatBridgeManager
 import xyz.bluspring.kilt.loader.asm.AccessTransformerLoader
+import xyz.bluspring.kilt.loader.asm.EnumExtensionLoader
 import xyz.bluspring.kilt.loader.asm.coremod.CoreModLoader
 import xyz.bluspring.kilt.loader.mod.KiltEnvironment
 import xyz.bluspring.kilt.loader.mod.NeoForgeMod
@@ -529,8 +530,10 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
         // Load mod access transformers and coremods
         for (mod in mods) {
             loadTransformers(mod)
+            EnumExtensionLoader.loadEnumExtension(mod)
             CoreModLoader.scanAndLoadCoreMods(mod)
         }
+        EnumExtensionLoader.applyEnumExtensions()
     }
 
     override suspend fun createModContainers(definitions: Collection<ModDefinition>): Collection<NeoForgeMod> {

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/AccessTransformerLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/AccessTransformerLoader.kt
@@ -1,11 +1,11 @@
 package xyz.bluspring.kilt.loader.asm
 
-import com.chocohead.mm.api.ClassTinkerers
 import net.fabricmc.loader.impl.FabricLoaderImpl
 import net.fabricmc.loader.impl.lib.classtweaker.api.ClassTweaker
 import net.fabricmc.loader.impl.lib.classtweaker.api.visitor.AccessWidenerVisitor
 import org.objectweb.asm.Opcodes
 import org.slf4j.LoggerFactory
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import xyz.bluspring.kilt.loader.KiltFlags
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import java.util.regex.Pattern

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -18,7 +18,7 @@ import java.util.function.Consumer
 
 object EnumExtensionLoader {
 
-    val enumExtensions = mutableMapOf<String, MutableSet<EnumPrototype>>()
+    val enumExtensions = mutableSetOf<EnumPrototype>()
     val proxies = mutableMapOf<String, MutableMap<String, EnumParameters.FieldReference>>()
     val indexed = mutableMapOf<String, Int>()
 
@@ -40,10 +40,7 @@ object EnumExtensionLoader {
                 if (Files.isRegularFile(path)) {
                     EnumPrototype.load(mod, path).forEach { prototype ->
                         val usablePrototype = remapPrototype(prototype)
-                        enumExtensions.computeIfAbsent(
-                            usablePrototype.enumName,
-                            { TreeSet() }
-                        ).add(usablePrototype)
+                        enumExtensions.add(usablePrototype)
                     }
                 }
             }
@@ -95,45 +92,43 @@ object EnumExtensionLoader {
     }
 
     fun applyEnumExtensions() {
-        enumExtensions.forEach { (name, prototypes) ->
-            for (prototype in prototypes) {
-                val descriptor = Type.getType(prototype.ctorDesc)
-                val parameters = prototype.ctorParams
-                if (parameters is EnumParameters.FieldReference) {
-                    proxies.computeIfAbsent(prototype.enumName, {mutableMapOf()})[prototype.fieldName] = parameters
-                }
-                ClassTinkerers.enumBuilder(
-                    prototype.enumName, *descriptor.argumentTypes
-                ).addEnum(
-                    prototype.fieldName, {
-                        when (parameters) {
-                            is EnumParameters.Constant -> parameters.params
-                            is EnumParameters.FieldReference -> {
-                                val proxy = getEnumProxy(parameters)
-                                val args = mutableListOf<Any?>()
-                                for (i in 0 until descriptor.argumentCount) {
-                                    args.add(proxy.getParameter(i))
-                                }
-                                args
-                            }
-                            is EnumParameters.MethodReference -> {
-                                // Luckily for us, NeoForge crashes unless these are public.
-                                // This is good because getDeclaredMethod might crash the game on servers.
-                                val method = Class.forName(parameters.owner.className).getMethod(parameters.methodName, Integer.TYPE, Class::class.java)
-                                val args = mutableListOf<Any?>()
-                                for (i in 0 until descriptor.argumentCount) {
-                                    if (indexed[name] == i) {
-                                        args.add(-1)
-                                    } else {
-                                        args.add(method.invoke(null, i, getCastClass(descriptor.argumentTypes[i])))
-                                    }
-                                }
-                                args
-                            }
-                        }.toTypedArray()
-                    }
-                ).build()
+        for (prototype in enumExtensions) {
+            val descriptor = Type.getType(prototype.ctorDesc)
+            val parameters = prototype.ctorParams
+            if (parameters is EnumParameters.FieldReference) {
+                proxies.computeIfAbsent(prototype.enumName, {mutableMapOf()})[prototype.fieldName] = parameters
             }
+            ClassTinkerers.enumBuilder(
+                prototype.enumName, *descriptor.argumentTypes
+            ).addEnum(
+                prototype.fieldName, {
+                    when (parameters) {
+                        is EnumParameters.Constant -> parameters.params
+                        is EnumParameters.FieldReference -> {
+                            val proxy = getEnumProxy(parameters)
+                            val args = mutableListOf<Any?>()
+                            for (i in 0 until descriptor.argumentCount) {
+                                args.add(proxy.getParameter(i))
+                            }
+                            args
+                        }
+                        is EnumParameters.MethodReference -> {
+                            // Luckily for us, NeoForge crashes unless these are public.
+                            // This is good because getDeclaredMethod might crash the game on servers.
+                            val method = Class.forName(parameters.owner.className).getMethod(parameters.methodName, Integer.TYPE, Class::class.java)
+                            val args = mutableListOf<Any?>()
+                            for (i in 0 until descriptor.argumentCount) {
+                                if (indexed[prototype.enumName] == i) {
+                                    args.add(-1)
+                                } else {
+                                    args.add(method.invoke(null, i, getCastClass(descriptor.argumentTypes[i])))
+                                }
+                            }
+                            args
+                        }
+                    }.toTypedArray()
+                }
+            ).build()
         }
     }
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -107,7 +107,7 @@ object EnumExtensionLoader {
                             is EnumParameters.Constant -> parameters.params
                             is EnumParameters.FieldReference -> {
                                 val proxy = getEnumProxy(parameters)
-                                val args = mutableListOf<Any>()
+                                val args = mutableListOf<Any?>()
                                 for (i in 0..< descriptor.argumentCount) {
                                     args.add(proxy.getParameter(i))
                                 }
@@ -117,7 +117,7 @@ object EnumExtensionLoader {
                                 // Luckily for us, NeoForge crashes unless these are public.
                                 // This is good because getDeclaredMethod might crash the game on servers.
                                 val method = Class.forName(parameters.owner.className).getMethod(parameters.methodName, Integer.TYPE, Class::class.java)
-                                val args = mutableListOf<Any>()
+                                val args = mutableListOf<Any?>()
                                 for (i in 0..< descriptor.argumentCount) {
                                     if (indexed[name] == i) {
                                         args.add(-1)

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -222,10 +222,20 @@ object EnumExtensionLoader {
                     newIndex++
                 }
 
+                val valuesName = KiltRemapper.enhancedRemapper.mapFieldName(
+                    KiltRemapper.unmapClass(targetClass.name),
+                    $$"$VALUES",
+                    "[L${KiltRemapper.unmapClass(targetClass.name)};"
+                )
+
                 // Sort the $VALUES array based on the ordinal after it has been set for the last time.
                 val fixValuesOrder = InsnList()
                 fixValuesOrder.add(LabelNode())
-                fixValuesOrder.add(FieldInsnNode(Opcodes.GETSTATIC, targetClass.name, $$"$VALUES", "[L${targetClass.name};"))
+                fixValuesOrder.add(FieldInsnNode(
+                    Opcodes.GETSTATIC, targetClass.name,
+                    valuesName,
+                    "[L${targetClass.name};"
+                ))
 
                 fixValuesOrder.add(InvokeDynamicInsnNode(
                     "apply", "()Ljava/util/function/Function;",
@@ -244,7 +254,7 @@ object EnumExtensionLoader {
 
                 var setValuesIndex = 0
                 for (ins in clinit.instructions) {
-                    if (ins is FieldInsnNode && ins.name == $$"$VALUES" && ins.owner == targetClass.name && ins.desc == "[L${targetClass.name};" && ins.opcode == Opcodes.PUTSTATIC) {
+                    if (ins is FieldInsnNode && ins.name == valuesName && ins.owner == targetClass.name && ins.desc == "[L${targetClass.name};" && ins.opcode == Opcodes.PUTSTATIC) {
                         setValuesIndex = clinit.instructions.indexOf(ins)
                     }
                 }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -23,13 +23,12 @@ object EnumExtensionLoader {
     val indexed = mutableMapOf<String, Int>()
 
     private fun remapPrototype(prototype: EnumPrototype): EnumPrototype {
-        if (FabricLoader.getInstance().isDevelopmentEnvironment) return prototype
         return EnumPrototype(
             prototype.owningMod,
-            KiltRemapper.remapClass(prototype.enumName, toIntermediary = true),
+            KiltRemapper.remapClass(prototype.enumName, toIntermediary = !FabricLoader.getInstance().isDevelopmentEnvironment),
             prototype.fieldName,
-            KiltRemapper.remapDescriptor(prototype.ctorDesc, toIntermediary = true),
-            KiltRemapper.remapDescriptor(prototype.fullCtorDesc, toIntermediary = true),
+            KiltRemapper.remapDescriptor(prototype.ctorDesc, toIntermediary = !FabricLoader.getInstance().isDevelopmentEnvironment),
+            KiltRemapper.remapDescriptor(prototype.fullCtorDesc, toIntermediary = !FabricLoader.getInstance().isDevelopmentEnvironment),
             prototype.ctorParams
         )
     }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -2,7 +2,6 @@ package xyz.bluspring.kilt.loader.asm
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
-import net.fabricmc.loader.api.FabricLoader
 import net.neoforged.fml.common.asm.enumextension.*
 import net.neoforged.fml.common.asm.enumextension.NetworkedEnum.NetworkCheck
 import org.objectweb.asm.Handle
@@ -36,10 +35,10 @@ object EnumExtensionLoader {
 
     fun loadEnumExtension(mod: NeoForgeMod) {
         mod.config.getConfigList("mods").forEach { config ->
-            config.getConfigElement<String>("enumExtensions").ifPresent{ file ->
+            config.getConfigElement<String>("enumExtensions").ifPresent { file ->
                 val path = mod.owningFile.getFile().findResource(file)
                 if (Files.isRegularFile(path)) {
-                    EnumPrototype.load(mod, path).forEach{ prototype ->
+                    EnumPrototype.load(mod, path).forEach { prototype ->
                         val usablePrototype = remapPrototype(prototype)
                         enumExtensions.computeIfAbsent(
                             usablePrototype.enumName,
@@ -51,11 +50,14 @@ object EnumExtensionLoader {
         }
     }
 
-    private fun <T> forceSetEnumProxyValue(proxy: EnumProxy<T>, value: Any) where T: Enum<T>, T: IExtensibleEnum {
+    private fun <T> forceSetEnumProxyValue(proxy: EnumProxy<T>, value: Any) where T : Enum<T>, T : IExtensibleEnum {
         @Suppress("UNCHECKED_CAST")
         proxy.value = value as T
     }
 
+
+    //Keep this constant close to the function below.
+    val SET_PROXY_VALUE_TARGET_CLASS = javaClass.name.replace(".", "/")
     //Automatically invoked by enums after enum extension, DO NOT DELETE!
     @Suppress("unused")
     fun setProxyValue(enumName: String, fieldName: String, enum: Any) {
@@ -135,7 +137,7 @@ object EnumExtensionLoader {
         }
     }
 
-    val INITIAL_ENUM_COUNTS: Object2IntMap<String?> = Object2IntOpenHashMap<String?>()
+    val INITIAL_ENUM_COUNTS: Object2IntMap<String> = Object2IntOpenHashMap()
     const val EXTENSIBLE_ENUM: String = "net/neoforged/fml/common/asm/enumextension/IExtensibleEnum"
 
     private fun countEnumFields(classNode: ClassNode): Int {
@@ -157,19 +159,18 @@ object EnumExtensionLoader {
             // I decided to set this parameter to the same value as ordinal for all values since there isn't really any good reason to allow Fabric mods to set their own values here.
             val indexed = Annotations.getInvisible(mixinClass, IndexedEnum::class.java)
             if (indexed != null) {
-                var index = Annotations.getValue<Number?>(indexed)
+                var index = Annotations.getValue<Int>(indexed)
                 if (index == null) {
                     index = 0
                 }
-				EnumExtensionLoader.indexed[targetClass.name] = index.toInt()
-				val fixedIndex = index.toInt()
-                targetClass.methods.stream().filter { method -> method!!.name == "<init>" }
+				EnumExtensionLoader.indexed[targetClass.name] = index
+				targetClass.methods.filter { method -> method.name == "<init>" }
                     .forEach { constructor ->
                         val list = InsnList()
                         list.add(LabelNode())
                         list.add(VarInsnNode(Opcodes.ILOAD, 2))
-                        list.add(VarInsnNode(Opcodes.ISTORE, 3 + fixedIndex))
-                        constructor!!.instructions.insertBefore(constructor.instructions.getFirst(), list)
+                        list.add(VarInsnNode(Opcodes.ISTORE, 3 + index))
+                        constructor.instructions.insertBefore(constructor.instructions.getFirst(), list)
                     }
             }
         }
@@ -177,15 +178,13 @@ object EnumExtensionLoader {
 
     fun postApplyEnum(targetClass: ClassNode, mixinClass: ClassNode) {
         if (mixinClass.interfaces.contains(EXTENSIBLE_ENUM)) {
-            val clinit =
-                targetClass.methods.stream().filter { method -> method!!.name == "<clinit>" }.findFirst()
-                    .orElseThrow()
+            val clinit = targetClass.methods.first { it.name == "<clinit>" }
 
             val vanillaCount = INITIAL_ENUM_COUNTS.getOrDefault(targetClass.name, 0)
 
             // Make sure the ordinal parameter does not change between reboots.
             let {
-                val enumPositions: TreeMap<String, Int> = TreeMap()
+                val enumPositions = TreeMap<String, Int>()
                 var vanillaRemaining = vanillaCount
                 for (i in 0 until clinit.instructions.size()) {
                     when (val ins = clinit.instructions.get(i)) {
@@ -266,13 +265,12 @@ object EnumExtensionLoader {
 			proxies?.keys?.forEach(Consumer { fieldName: String? ->
 				val fillProxy = InsnList()
 				fillProxy.add(LabelNode())
-				val enumExtensionLoader = "xyz/bluspring/kilt/loader/asm/EnumExtensionLoader"
 				fillProxy.add(
 					FieldInsnNode(
 						Opcodes.GETSTATIC,
-						enumExtensionLoader,
+                        SET_PROXY_VALUE_TARGET_CLASS,
 						"INSTANCE",
-						"L$enumExtensionLoader;"
+						"L$SET_PROXY_VALUE_TARGET_CLASS;"
 					)
 				)
 				fillProxy.add(LdcInsnNode(targetClass.name))
@@ -288,7 +286,7 @@ object EnumExtensionLoader {
 				fillProxy.add(
 					MethodInsnNode(
 						Opcodes.INVOKEVIRTUAL,
-						enumExtensionLoader,
+                        SET_PROXY_VALUE_TARGET_CLASS,
 						"setProxyValue",
 						"(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V"
 					)
@@ -356,11 +354,11 @@ object EnumExtensionLoader {
                     clinit.maxStack = 6
                 }
                 clinit.instructions.insertBefore(clinit.instructions.getLast(), fieldSetup)
-                val getExtensionInfo = targetClass.methods.stream().filter { method ->
-                    method!!.name == "getExtensionInfo" &&
-                            method.desc == "()$extensionInfoDesc" &&
-                            (method.access and Opcodes.ACC_STATIC) != 0
-                }.findFirst().orElseThrow()
+                val getExtensionInfo = targetClass.methods.first {
+                    it.name == "getExtensionInfo" &&
+                    it.desc == "()$extensionInfoDesc" &&
+                    (it.access and Opcodes.ACC_STATIC) != 0
+                }
                 getExtensionInfo.instructions.clear()
                 getExtensionInfo.instructions.add(LabelNode())
                 getExtensionInfo.instructions.add(

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -1,0 +1,316 @@
+package xyz.bluspring.kilt.loader.asm
+
+import com.chocohead.mm.api.ClassTinkerers
+import it.unimi.dsi.fastutil.objects.Object2IntMap
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
+import net.fabricmc.loader.api.FabricLoader
+import net.neoforged.fml.common.asm.enumextension.*
+import net.neoforged.fml.common.asm.enumextension.NetworkedEnum.NetworkCheck
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.*
+import org.spongepowered.asm.util.Annotations
+import xyz.bluspring.kilt.loader.mod.NeoForgeMod
+import xyz.bluspring.kilt.loader.remap.KiltRemapper
+import java.nio.file.Files
+import java.util.*
+import java.util.function.Consumer
+
+object EnumExtensionLoader {
+
+    val enumExtensions = mutableMapOf<String, MutableSet<EnumPrototype>>()
+    val proxies = mutableMapOf<String, MutableMap<String, EnumParameters.FieldReference>>()
+    val indexed = mutableMapOf<String, Int>()
+
+    private fun remapPrototype(prototype: EnumPrototype): EnumPrototype {
+        if (FabricLoader.getInstance().isDevelopmentEnvironment) return prototype
+        return EnumPrototype(
+            prototype.owningMod,
+            KiltRemapper.remapClass(prototype.enumName, toIntermediary = true),
+            prototype.fieldName,
+            KiltRemapper.remapDescriptor(prototype.ctorDesc, toIntermediary = true),
+            KiltRemapper.remapDescriptor(prototype.fullCtorDesc, toIntermediary = true),
+            prototype.ctorParams
+        )
+    }
+
+    fun loadEnumExtension(mod: NeoForgeMod) {
+        mod.config.getConfigList("mods").forEach { config ->
+            config.getConfigElement<String>("enumExtensions").ifPresent{ file ->
+                val path = mod.owningFile.getFile().findResource(file)
+                if (Files.isRegularFile(path)) {
+                    EnumPrototype.load(mod, path).forEach{ prototype ->
+                        val usablePrototype = remapPrototype(prototype)
+                        enumExtensions.computeIfAbsent(
+                            usablePrototype.enumName,
+                            { TreeSet() }
+                        ).add(usablePrototype)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun <T> forceSetEnumProxyValue(proxy: EnumProxy<T>, value: Any) where T: Enum<T>, T: IExtensibleEnum {
+        @Suppress("UNCHECKED_CAST")
+        proxy.value = value as T
+    }
+
+    //Automatically invoked by enums after enum extension, DO NOT DELETE!
+    @Suppress("unused")
+    fun setProxyValue(enumName: String, fieldName: String, enum: Any) {
+        if (enum !is Enum<*> || enum !is IExtensibleEnum) {
+            return
+        }
+        val proxyField = proxies[enumName]?.get(fieldName)
+        if (proxyField != null) {
+            val proxy = getEnumProxy(proxyField)
+            forceSetEnumProxyValue(proxy, enum)
+        }
+    }
+
+    private fun getEnumProxy(fieldReference: EnumParameters.FieldReference): EnumProxy<*> {
+        return Class.forName(fieldReference.owner.className).getDeclaredField(fieldReference.fieldName).get(null) as EnumProxy<*>
+    }
+
+    private fun getCastClass(type: Type): Class<*> {
+        return when (type.sort) {
+            Type.VOID -> Void.TYPE
+            Type.BOOLEAN -> java.lang.Boolean.TYPE
+            Type.BYTE -> java.lang.Byte.TYPE
+            Type.SHORT -> java.lang.Short.TYPE
+            Type.INT -> Integer.TYPE
+            Type.LONG -> java.lang.Long.TYPE
+            Type.FLOAT -> java.lang.Float.TYPE
+            Type.DOUBLE -> java.lang.Double.TYPE
+            Type.CHAR -> Character.TYPE
+            Type.ARRAY -> {
+                var clazz = Class.forName(type.internalName.replace("/", "."))
+                for (i in 0 ..< type.dimensions) {
+                    clazz = clazz.arrayType()
+                }
+				clazz
+            }
+            Type.OBJECT -> Class.forName(type.className)
+            else -> throw IllegalStateException("Could not find the class for $type")
+        }
+    }
+
+    fun applyEnumExtensions() {
+        enumExtensions.forEach { (name, prototypes) ->
+            for (prototype in prototypes) {
+                val descriptor = Type.getType(prototype.ctorDesc)
+                val parameters = prototype.ctorParams
+                if (parameters is EnumParameters.FieldReference) {
+                    proxies.computeIfAbsent(prototype.enumName, {mutableMapOf()})[prototype.fieldName] = parameters
+                }
+                ClassTinkerers.enumBuilder(
+                    prototype.enumName, *descriptor.argumentTypes
+                ).addEnum(
+                    prototype.fieldName, {
+                        when (parameters) {
+                            is EnumParameters.Constant -> parameters.params
+                            is EnumParameters.FieldReference -> {
+                                val proxy = getEnumProxy(parameters)
+                                val args = mutableListOf<Any>()
+                                for (i in 0..< descriptor.argumentCount) {
+                                    args.add(proxy.getParameter(i))
+                                }
+                                args
+                            }
+                            is EnumParameters.MethodReference -> {
+                                val method = Class.forName(parameters.owner.className).getDeclaredMethod(parameters.methodName, Integer.TYPE, Class::class.java)
+                                val args = mutableListOf<Any>()
+                                for (i in 0..< descriptor.argumentCount) {
+                                    if (indexed[name] == i) {
+                                        args.add(-1)
+                                    } else {
+                                        args.add(method.invoke(null, i, getCastClass(descriptor.argumentTypes[i])))
+                                    }
+                                }
+                                args
+                            }
+                        }.toTypedArray()
+                    }
+                ).build()
+            }
+        }
+    }
+
+    val INITIAL_ENUM_COUNTS: Object2IntMap<String?> = Object2IntOpenHashMap<String?>()
+    const val EXTENSIBLE_ENUM: String = "net/neoforged/fml/common/asm/enumextension/IExtensibleEnum"
+
+    private fun countEnumFields(classNode: ClassNode): Int {
+        var count = 0
+        for (field in classNode.fields) {
+            if (field.desc == "L" + classNode.name + ";" && (field.access and Opcodes.ACC_STATIC) != 0) {
+                count++
+            }
+        }
+        return count
+    }
+
+    fun preApplyEnum(targetClass: ClassNode, mixinClass: ClassNode) {
+        if (mixinClass.interfaces.contains(EXTENSIBLE_ENUM)) {
+            // Note how many enum constants exist before mixin injection.
+            INITIAL_ENUM_COUNTS.put(targetClass.name, countEnumFields(targetClass))
+
+            // Handle IndexedEnums since NeoForge mods always set index to -1.
+            // I decided to set this parameter to the same value as ordinal for all values since there isn't really any good reason to allow Fabric mods to set their own values here.
+            val indexed = Annotations.getInvisible(mixinClass, IndexedEnum::class.java)
+            if (indexed != null) {
+                var index = Annotations.getValue<Number?>(indexed)
+                if (index == null) {
+                    index = 0
+                }
+				EnumExtensionLoader.indexed[targetClass.name] = index.toInt()
+				val fixedIndex = index.toInt()
+                targetClass.methods.stream().filter { method: MethodNode? -> method!!.name == "<init>" }
+                    .forEach { constructor: MethodNode? ->
+                        val list = InsnList()
+                        list.add(LabelNode())
+                        list.add(VarInsnNode(Opcodes.ILOAD, 2))
+                        list.add(VarInsnNode(Opcodes.ISTORE, 3 + fixedIndex))
+                        constructor!!.instructions.insertBefore(constructor.instructions.getFirst(), list)
+                    }
+            }
+        }
+    }
+
+    fun postApplyEnum(targetClass: ClassNode, mixinClass: ClassNode) {
+        if (mixinClass.interfaces.contains(EXTENSIBLE_ENUM)) {
+            val clinit =
+                targetClass.methods.stream().filter { method: MethodNode? -> method!!.name == "<clinit>" }.findFirst()
+                    .orElseThrow()
+
+            // Fill all EnumProxy instances.
+            val proxies = proxies.get(targetClass.name)
+			proxies?.keys?.forEach(Consumer { fieldName: String? ->
+				val fillProxy = InsnList()
+				fillProxy.add(LabelNode())
+				val enumExtensionLoader = "xyz/bluspring/kilt/loader/asm/EnumExtensionLoader"
+				fillProxy.add(
+					FieldInsnNode(
+						Opcodes.GETSTATIC,
+						enumExtensionLoader,
+						"INSTANCE",
+						"L$enumExtensionLoader;"
+					)
+				)
+				fillProxy.add(LdcInsnNode(targetClass.name))
+				fillProxy.add(LdcInsnNode(fieldName))
+				fillProxy.add(
+					FieldInsnNode(
+						Opcodes.GETSTATIC,
+						targetClass.name,
+						fieldName,
+						"L" + targetClass.name + ";"
+					)
+				)
+				fillProxy.add(
+					MethodInsnNode(
+						Opcodes.INVOKEVIRTUAL,
+						enumExtensionLoader,
+						"setProxyValue",
+						"(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V"
+					)
+				)
+				clinit.instructions.insertBefore(clinit.instructions.getLast(), fillProxy)
+			})
+
+            // Overwrite getExtensionInfo
+            val currentCount = countEnumFields(targetClass)
+            val vanillaCount = INITIAL_ENUM_COUNTS.getOrDefault(targetClass.name, 0)
+            if (currentCount != vanillaCount) {
+                var networkCheck: NetworkCheck? = null
+                val networked = Annotations.getVisible(mixinClass, NetworkedEnum::class.java)
+                if (networked != null) {
+                    networkCheck = NetworkCheck.valueOf(Annotations.getValue<Array<String?>>(networked)[1]!!)
+                }
+                val extensionInfoName = "net/neoforged/fml/common/asm/enumextension/ExtensionInfo"
+                val extensionInfoDesc = "L$extensionInfoName;"
+                val extensionInfoField = "kilt\$extensionInfo"
+                targetClass.fields.add(
+                    FieldNode(
+                        Opcodes.ACC_PRIVATE or Opcodes.ACC_STATIC or Opcodes.ACC_FINAL, extensionInfoField,
+                        extensionInfoDesc, extensionInfoDesc, null
+                    )
+                )
+                val fieldSetup = InsnList()
+                fieldSetup.add(LabelNode())
+                fieldSetup.add(TypeInsnNode(Opcodes.NEW, extensionInfoName))
+                fieldSetup.add(InsnNode(Opcodes.DUP))
+                fieldSetup.add(InsnNode(Opcodes.ICONST_1)) // Set extended to true.
+                fieldSetup.add(pushInt(vanillaCount))
+                fieldSetup.add(pushInt(currentCount))
+
+                if (networkCheck == null) {
+                    fieldSetup.add(InsnNode(Opcodes.ACONST_NULL))
+                } else {
+                    val networkCheckClassName = NetworkCheck::class.java.getName().replace(".", "/")
+                    fieldSetup.add(
+                        FieldInsnNode(
+                            Opcodes.GETSTATIC,
+                            networkCheckClassName,
+                            networkCheck.name,
+							"L$networkCheckClassName;"
+                        )
+                    )
+                }
+
+                fieldSetup.add(
+                    MethodInsnNode(
+                        Opcodes.INVOKESPECIAL,
+                        extensionInfoName,
+                        "<init>",
+                        "(ZIILnet/neoforged/fml/common/asm/enumextension/NetworkedEnum\$NetworkCheck;)V"
+                    )
+                )
+
+                fieldSetup.add(
+                    FieldInsnNode(
+                        Opcodes.PUTSTATIC,
+                        targetClass.name,
+                        extensionInfoField,
+                        extensionInfoDesc
+                    )
+                )
+                if (clinit.maxStack < 6) {
+                    clinit.maxStack = 6
+                }
+                clinit.instructions.insertBefore(clinit.instructions.getLast(), fieldSetup)
+                val getExtensionInfo = targetClass.methods.stream().filter { method: MethodNode? ->
+                    method!!.name == "getExtensionInfo" &&
+                            method.desc == "()$extensionInfoDesc" &&
+                            (method.access and Opcodes.ACC_STATIC) != 0
+                }.findFirst().orElseThrow()
+                getExtensionInfo.instructions.clear()
+                getExtensionInfo.instructions.add(LabelNode())
+                getExtensionInfo.instructions.add(
+                    FieldInsnNode(
+                        Opcodes.GETSTATIC,
+                        targetClass.name,
+                        extensionInfoField,
+                        extensionInfoDesc
+                    )
+                )
+                getExtensionInfo.instructions.add(InsnNode(Opcodes.ARETURN))
+                getExtensionInfo.maxStack = 1
+            }
+        }
+    }
+
+    private fun pushInt(num: Int): AbstractInsnNode {
+        return when (num) {
+            -1 -> InsnNode(Opcodes.ICONST_M1)
+            0 -> InsnNode(Opcodes.ICONST_0)
+            1 -> InsnNode(Opcodes.ICONST_1)
+            2 -> InsnNode(Opcodes.ICONST_2)
+            3 -> InsnNode(Opcodes.ICONST_3)
+            4 -> InsnNode(Opcodes.ICONST_4)
+            5 -> InsnNode(Opcodes.ICONST_5)
+            else -> IntInsnNode(Opcodes.BIPUSH, num)
+        }
+    }
+    
+}

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -83,13 +83,7 @@ object EnumExtensionLoader {
             Type.FLOAT -> java.lang.Float.TYPE
             Type.DOUBLE -> java.lang.Double.TYPE
             Type.CHAR -> Character.TYPE
-            Type.ARRAY -> {
-                var clazz = Class.forName(type.internalName.replace("/", "."))
-                for (i in 0 ..< type.dimensions) {
-                    clazz = clazz.arrayType()
-                }
-				clazz
-            }
+            Type.ARRAY -> Class.forName(type.internalName.replace("/", "."))
             Type.OBJECT -> Class.forName(type.className)
             else -> throw IllegalStateException("Could not find the class for $type")
         }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -25,10 +25,10 @@ object EnumExtensionLoader {
     private fun remapPrototype(prototype: EnumPrototype): EnumPrototype {
         return EnumPrototype(
             prototype.owningMod,
-            KiltRemapper.remapClass(prototype.enumName, toIntermediary = !FabricLoader.getInstance().isDevelopmentEnvironment),
+            KiltRemapper.remapClass(prototype.enumName),
             prototype.fieldName,
-            KiltRemapper.remapDescriptor(prototype.ctorDesc, toIntermediary = !FabricLoader.getInstance().isDevelopmentEnvironment),
-            KiltRemapper.remapDescriptor(prototype.fullCtorDesc, toIntermediary = !FabricLoader.getInstance().isDevelopmentEnvironment),
+            KiltRemapper.remapDescriptor(prototype.ctorDesc),
+            KiltRemapper.remapDescriptor(prototype.fullCtorDesc),
             prototype.ctorParams
         )
     }
@@ -74,17 +74,17 @@ object EnumExtensionLoader {
         return Class.forName(fieldReference.owner.className).getField(fieldReference.fieldName).get(null) as EnumProxy<*>
     }
 
-    private fun getCastClass(type: Type): Class<*> {
+    private fun getCastClass(type: Type): Class<*>? {
         return when (type.sort) {
-            Type.VOID -> Void.TYPE
-            Type.BOOLEAN -> java.lang.Boolean.TYPE
-            Type.BYTE -> java.lang.Byte.TYPE
-            Type.SHORT -> java.lang.Short.TYPE
-            Type.INT -> Integer.TYPE
-            Type.LONG -> java.lang.Long.TYPE
-            Type.FLOAT -> java.lang.Float.TYPE
-            Type.DOUBLE -> java.lang.Double.TYPE
-            Type.CHAR -> Character.TYPE
+            Type.VOID -> Void::class.javaPrimitiveType
+            Type.BOOLEAN -> Boolean::class.javaPrimitiveType
+            Type.BYTE -> Byte::class.javaPrimitiveType
+            Type.SHORT -> Short::class.javaPrimitiveType
+            Type.INT -> Int::class.javaPrimitiveType
+            Type.LONG -> Long::class.javaPrimitiveType
+            Type.FLOAT -> Float::class.javaPrimitiveType
+            Type.DOUBLE -> Double::class.javaPrimitiveType
+            Type.CHAR -> Char::class.javaPrimitiveType
             Type.ARRAY -> Class.forName(type.internalName.replace("/", "."))
             Type.OBJECT -> Class.forName(type.className)
             else -> throw IllegalStateException("Could not find the class for $type")
@@ -108,7 +108,7 @@ object EnumExtensionLoader {
                             is EnumParameters.FieldReference -> {
                                 val proxy = getEnumProxy(parameters)
                                 val args = mutableListOf<Any?>()
-                                for (i in 0..< descriptor.argumentCount) {
+                                for (i in 0 until descriptor.argumentCount) {
                                     args.add(proxy.getParameter(i))
                                 }
                                 args
@@ -118,7 +118,7 @@ object EnumExtensionLoader {
                                 // This is good because getDeclaredMethod might crash the game on servers.
                                 val method = Class.forName(parameters.owner.className).getMethod(parameters.methodName, Integer.TYPE, Class::class.java)
                                 val args = mutableListOf<Any?>()
-                                for (i in 0..< descriptor.argumentCount) {
+                                for (i in 0 until descriptor.argumentCount) {
                                     if (indexed[name] == i) {
                                         args.add(-1)
                                     } else {
@@ -140,7 +140,7 @@ object EnumExtensionLoader {
     private fun countEnumFields(classNode: ClassNode): Int {
         var count = 0
         for (field in classNode.fields) {
-            if (field.desc == "L" + classNode.name + ";" && (field.access and Opcodes.ACC_STATIC) != 0) {
+            if (field.desc == "L${classNode.name};" && (field.access and Opcodes.ACC_STATIC) != 0) {
                 count++
             }
         }
@@ -162,8 +162,8 @@ object EnumExtensionLoader {
                 }
 				EnumExtensionLoader.indexed[targetClass.name] = index.toInt()
 				val fixedIndex = index.toInt()
-                targetClass.methods.stream().filter { method: MethodNode? -> method!!.name == "<init>" }
-                    .forEach { constructor: MethodNode? ->
+                targetClass.methods.stream().filter { method -> method!!.name == "<init>" }
+                    .forEach { constructor ->
                         val list = InsnList()
                         list.add(LabelNode())
                         list.add(VarInsnNode(Opcodes.ILOAD, 2))
@@ -177,7 +177,7 @@ object EnumExtensionLoader {
     fun postApplyEnum(targetClass: ClassNode, mixinClass: ClassNode) {
         if (mixinClass.interfaces.contains(EXTENSIBLE_ENUM)) {
             val clinit =
-                targetClass.methods.stream().filter { method: MethodNode? -> method!!.name == "<clinit>" }.findFirst()
+                targetClass.methods.stream().filter { method -> method!!.name == "<clinit>" }.findFirst()
                     .orElseThrow()
 
             // Fill all EnumProxy instances.
@@ -276,7 +276,7 @@ object EnumExtensionLoader {
                     clinit.maxStack = 6
                 }
                 clinit.instructions.insertBefore(clinit.instructions.getLast(), fieldSetup)
-                val getExtensionInfo = targetClass.methods.stream().filter { method: MethodNode? ->
+                val getExtensionInfo = targetClass.methods.stream().filter { method ->
                     method!!.name == "getExtensionInfo" &&
                             method.desc == "()$extensionInfoDesc" &&
                             (method.access and Opcodes.ACC_STATIC) != 0

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -69,7 +69,9 @@ object EnumExtensionLoader {
     }
 
     private fun getEnumProxy(fieldReference: EnumParameters.FieldReference): EnumProxy<*> {
-        return Class.forName(fieldReference.owner.className).getDeclaredField(fieldReference.fieldName).get(null) as EnumProxy<*>
+        // Luckily for us, NeoForge crashes unless these are public.
+        // This is good because getDeclaredField might crash the game on servers.
+        return Class.forName(fieldReference.owner.className).getField(fieldReference.fieldName).get(null) as EnumProxy<*>
     }
 
     private fun getCastClass(type: Type): Class<*> {
@@ -112,7 +114,9 @@ object EnumExtensionLoader {
                                 args
                             }
                             is EnumParameters.MethodReference -> {
-                                val method = Class.forName(parameters.owner.className).getDeclaredMethod(parameters.methodName, Integer.TYPE, Class::class.java)
+                                // Luckily for us, NeoForge crashes unless these are public.
+                                // This is good because getDeclaredMethod might crash the game on servers.
+                                val method = Class.forName(parameters.owner.className).getMethod(parameters.methodName, Integer.TYPE, Class::class.java)
                                 val args = mutableListOf<Any>()
                                 for (i in 0..< descriptor.argumentCount) {
                                     if (indexed[name] == i) {

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -1,6 +1,5 @@
 package xyz.bluspring.kilt.loader.asm
 
-import com.chocohead.mm.api.ClassTinkerers
 import it.unimi.dsi.fastutil.objects.Object2IntMap
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import net.fabricmc.loader.api.FabricLoader
@@ -10,6 +9,7 @@ import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree.*
 import org.spongepowered.asm.util.Annotations
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import xyz.bluspring.kilt.loader.mod.NeoForgeMod
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import java.nio.file.Files

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -5,6 +5,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import net.fabricmc.loader.api.FabricLoader
 import net.neoforged.fml.common.asm.enumextension.*
 import net.neoforged.fml.common.asm.enumextension.NetworkedEnum.NetworkCheck
+import org.objectweb.asm.Handle
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree.*
@@ -180,6 +181,76 @@ object EnumExtensionLoader {
                 targetClass.methods.stream().filter { method -> method!!.name == "<clinit>" }.findFirst()
                     .orElseThrow()
 
+            val vanillaCount = INITIAL_ENUM_COUNTS.getOrDefault(targetClass.name, 0)
+
+            // Make sure the ordinal parameter does not change between reboots.
+            let {
+                val enumPositions: TreeMap<String, Int> = TreeMap()
+                var vanillaRemaining = vanillaCount
+                for (i in 0 until clinit.instructions.size()) {
+                    when (val ins = clinit.instructions.get(i)) {
+                        is MethodInsnNode -> {
+                            if (ins.name == "<init>" && ins.owner == targetClass.name) {
+                                val assign = ins.next
+                                if (assign is FieldInsnNode) {
+                                    // We don't want to change the ordinal of the vanilla parameters.
+                                    if (vanillaRemaining > 0) {
+                                        vanillaRemaining--
+                                        continue
+                                    }
+                                    enumPositions[assign.name] = i
+                                }
+                            }
+                        }
+                    }
+                }
+
+                val enumOrdinals = mutableMapOf<String, Int>()
+
+                // Overwrite the ordinals for each non-vanilla enum (including Fabric ones) based on their order in our map.
+                // This effectively sorts them in alphabetical order.
+                var newIndex = vanillaCount
+                for ((name, pos) in enumPositions) {
+                    val ins = clinit.instructions.get(pos)
+                    var prev = ins
+                    while (prev !is TypeInsnNode || prev.desc != targetClass.name || prev.opcode != Opcodes.NEW) {
+                        prev = prev.previous
+                    }
+                    enumOrdinals[name] = newIndex
+                    clinit.instructions.set(prev.next.next.next, pushInt(newIndex))
+
+                    newIndex++
+                }
+
+                // Sort the $VALUES array based on the ordinal after it has been set for the last time.
+                val fixValuesOrder = InsnList()
+                fixValuesOrder.add(LabelNode())
+                fixValuesOrder.add(FieldInsnNode(Opcodes.GETSTATIC, targetClass.name, $$"$VALUES", "[L${targetClass.name};"))
+
+                fixValuesOrder.add(InvokeDynamicInsnNode(
+                    "apply", "()Ljava/util/function/Function;",
+                    Handle(
+                        Opcodes.H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory", "metafactory",
+                        $$"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                        false
+                    ),
+                    Type.getType("(Ljava/lang/Object;)Ljava/lang/Object;"),
+                    Handle(Opcodes.H_INVOKEVIRTUAL, "java/lang/Enum", "ordinal", "()I", false),
+                    Type.getType("(L${targetClass.name};)Ljava/lang/Integer;")
+                ))
+
+                fixValuesOrder.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/util/Comparator", "comparing", "(Ljava/util/function/Function;)Ljava/util/Comparator;", true))
+                fixValuesOrder.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/util/Arrays", "sort", "([Ljava/lang/Object;Ljava/util/Comparator;)V", false))
+
+                var setValuesIndex = 0
+                for (ins in clinit.instructions) {
+                    if (ins is FieldInsnNode && ins.name == $$"$VALUES" && ins.owner == targetClass.name && ins.desc == "[L${targetClass.name};" && ins.opcode == Opcodes.PUTSTATIC) {
+                        setValuesIndex = clinit.instructions.indexOf(ins)
+                    }
+                }
+                clinit.instructions.insert(clinit.instructions[setValuesIndex], fixValuesOrder)
+            }
+
             // Fill all EnumProxy instances.
             val proxies = proxies.get(targetClass.name)
 			proxies?.keys?.forEach(Consumer { fieldName: String? ->
@@ -217,7 +288,6 @@ object EnumExtensionLoader {
 
             // Overwrite getExtensionInfo
             val currentCount = countEnumFields(targetClass)
-            val vanillaCount = INITIAL_ENUM_COUNTS.getOrDefault(targetClass.name, 0)
             if (currentCount != vanillaCount) {
                 var networkCheck: NetworkCheck? = null
                 val networked = Annotations.getVisible(mixinClass, NetworkedEnum::class.java)

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltEarlyRiser.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltEarlyRiser.kt
@@ -1,6 +1,5 @@
 package xyz.bluspring.kilt.loader.asm
 
-import com.chocohead.mm.api.ClassTinkerers
 import net.fabricmc.loader.api.FabricLoader
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
@@ -10,6 +9,7 @@ import org.objectweb.asm.tree.FieldInsnNode
 import org.objectweb.asm.tree.InsnList
 import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.VarInsnNode
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import xyz.bluspring.kilt.Kilt
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import xyz.bluspring.kilt.loader.remap.ObjectHolderDefinalizer

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/coremod/CoreMod.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/coremod/CoreMod.kt
@@ -1,6 +1,5 @@
 package xyz.bluspring.kilt.loader.asm.coremod
 
-import com.chocohead.mm.api.ClassTinkerers
 import net.neoforged.coremod.api.TargetType
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.FieldNode
@@ -8,6 +7,7 @@ import org.objectweb.asm.tree.MethodNode
 import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory
 import org.slf4j.LoggerFactory
 import org.slf4j.MarkerFactory
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import xyz.bluspring.kilt.loader.KiltFlags
 import xyz.bluspring.kilt.loader.KiltLoader
 import xyz.bluspring.kilt.loader.asm.NashornHelper

--- a/src/main/kotlin/xyz/bluspring/kilt/util/EnumUtils.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/EnumUtils.kt
@@ -1,10 +1,10 @@
 package xyz.bluspring.kilt.util
 
-import com.chocohead.mm.CasualStreamHandler
-import com.chocohead.mm.api.ClassTinkerers
 import com.mojang.serialization.Codec
 import net.minecraftforge.fml.unsafe.UnsafeHacks
 import net.neoforged.fml.common.asm.enumextension.IExtensibleEnum
+import xyz.bluspring.fork.mm.CasualStreamHandler
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import xyz.bluspring.kilt.Kilt
 import java.util.Locale.getDefault
 import java.util.function.Consumer

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
     "server": [
       "xyz.bluspring.kilt.server.dedicated.KiltDedicatedServer"
     ],
-    "mm:early_risers": [
+    "mm_kilt:early_risers": [
       "xyz.bluspring.kilt.loader.asm.KiltEarlyRiser"
     ],
     "mixinsquared-adjuster": [
@@ -51,7 +51,7 @@
     "fabric-api": ">=${fabric_version}",
     "minecraft": "${minecraft_version}",
     "fabric-language-kotlin": ">=${fabric_kotlin_version}",
-    "mm": ">=${fabric_asm_version}"
+    "mm_kilt": ">=${fabric_asm_version}"
   },
   "custom": {
     "kilt:access_transformer": [


### PR DESCRIPTION
This is the main logic for handling enum extensions. It depends on #776 to avoid crashing when mods try to use it.
It leaves the heavy lifting to Fabric ASM, and makes some smaller manual changes like rewriting `getExtensionInfo` and fixing the index of enums annotated as `@IndexedEnum`. For dealing with `@IndexedEnum`, I am currently just ignoring whatever parameter is provided and instead just forcefully set it to the same value as the ordinal parameter. This should hopefully help avoid issues if Fabric mods just insert a random value and hope for the best since we don't really know what order the enums will end up in `<clinit>`. It also injects initializers into <clinit> of the enum in question that initialize any EnumProxy instances that were referenced in the enum extensions.

Note that due to some enums relying on the integer id for networking, we might want to merge #773 alongside this to make sure the client and the server get the same load order.

The main drawback at the moment is that the Fabric ASM version we're using might run into re-entrance errors in some cases. So I'm marking it as a draft just in there are any mods that seem to work fine without enum extensions but would crash due to re-entrance because of this.