### PR TITLE
Fix player not passed to `FoodData::eat`.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/player/PlayerInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/player/PlayerInject.java
@@ -28,6 +28,7 @@ import net.minecraft.world.entity.boss.EnderDragonPart;
 import net.minecraft.world.entity.player.Abilities;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodData;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -51,10 +52,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import xyz.bluspring.kilt.helpers.mixin.CreateStatic;
@@ -205,6 +203,17 @@ public abstract class PlayerInject extends LivingEntity implements IForgePlayer,
         }
 
         return item;
+    }
+
+    @Redirect(
+            method = "eat",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/food/FoodData;eat(Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/ItemStack;)V"
+            )
+    )
+    private void kilt$eatWithPlayer(FoodData instance, Item item, ItemStack stack) {
+        instance.eat(item, stack, this);
     }
 
     @Inject(method = "stopSleepInBed", at = @At("HEAD"))

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/food/FoodDataInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/food/FoodDataInject.java
@@ -1,6 +1,7 @@
 // TRACKED HASH: 67468ffd11d7ad051ef0ba08d2f696e15a0b8fef
 package xyz.bluspring.kilt.forgeinjects.world.food;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -15,20 +16,34 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import xyz.bluspring.kilt.injections.world.food.FoodDataInjection;
+import xyz.bluspring.kilt.util.KiltHelper;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Mixin(FoodData.class)
 public abstract class FoodDataInject implements FoodDataInjection {
     @Shadow public abstract void eat(Item item, ItemStack stack);
 
+    @Unique private final AtomicBoolean kilt$calledForgeEat = new AtomicBoolean(false);
     @Unique private final AtomicReference<LivingEntity> kilt$entity = new AtomicReference<>(null);
+
+    @WrapMethod(method = "eat(Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/ItemStack;)V")
+    private void kilt$onFabricEat(Item item, ItemStack stack, Operation<Void> original) {
+        if (!kilt$calledForgeEat.get() && KiltHelper.INSTANCE.hasMethodOverride(this.getClass(), FoodData.class, "eat", Item.class, ItemStack.class, LivingEntity.class)) {
+            eat(item, stack, null);
+        } else {
+            original.call(item, stack);
+        }
+    }
 
     @Override
     public void eat(Item item, ItemStack stack, @Nullable LivingEntity entity) {
         this.kilt$entity.set(entity);
+        kilt$calledForgeEat.set(true);
         this.eat(item, stack);
         this.kilt$entity.set(null);
+        kilt$calledForgeEat.set(false);
     }
 
     @WrapOperation(method = "eat(Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/ItemStack;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/Item;getFoodProperties()Lnet/minecraft/world/food/FoodProperties;"))

--- a/src/main/java/xyz/bluspring/kilt/injections/world/food/FoodDataInjection.java
+++ b/src/main/java/xyz/bluspring/kilt/injections/world/food/FoodDataInjection.java
@@ -6,5 +6,7 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 public interface FoodDataInjection {
-    void eat(Item item, ItemStack stack, @Nullable LivingEntity entity);
+    default void eat(Item item, ItemStack stack, @Nullable LivingEntity entity)  {
+        throw new IllegalStateException();
+    }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -120,7 +120,8 @@
       "net/minecraft/class_1826": ["xyz/bluspring/kilt/injections/world/item/SpawnEggItemInjection"],
       "net/minecraft/class_1761": ["xyz/bluspring/kilt/injections/world/item/CreativeModeTabInjection"],
       "net/minecraft/class_1761$class_7913": ["xyz/bluspring/kilt/injections/world/item/CreativeModeTabInjection$BuilderInjection"],
-      "net/minecraft/class_702": ["xyz/bluspring/kilt/injections/client/particle/ParticleEngineInjection"]
+      "net/minecraft/class_702": ["xyz/bluspring/kilt/injections/client/particle/ParticleEngineInjection"],
+      "net/minecraft/class_1702": ["xyz/bluspring/kilt/injections/world/food/FoodDataInjection"]
     },
     "lithium:options": {
       "mixin.entity.collisions.fluid": false,


### PR DESCRIPTION
Fixes half of #751 (it mentions 2 issues). TFC overrides the forge variant of eat but ignores the vanilla one.

I wanted to keep this one separate because it introduces a new redirect which could potentially break Fabric mods with a redirect at the same place (I don't know any Fabric mods that do that though). I chose a redirect because there isn't really any good reason to call the original since the custom one will always call that one anyway (unless a mod like TFC overrides it in which case we probably don't want to run that anyway). A WrapOperation would just ignore the original, so then it would fail silently which is not ideal.