### PR TITLE
Fix fluid issues with TFC

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/EntityInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/EntityInject.java
@@ -13,6 +13,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import io.github.fabricators_of_create.porting_lib.entity.extensions.EntityExtensions;
 import io.github.fabricators_of_create.porting_lib.fluids.PortingLibFluids;
@@ -60,6 +61,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -439,9 +441,17 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
     }
 
     @WrapOperation(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "INVOKE", target = "Ljava/lang/Math;max(DD)D"))
-    private double kilt$useInterimCalc(double a, double b, Operation<Double> original, @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef, @Share("interim") LocalRef<MutableTriple<Double, Vec3, Integer>> interim) {
+    private double kilt$useInterimCalc(
+            double a, double b, Operation<Double> original,
+            @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs,
+            @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef,
+            @Share("interim") LocalRef<MutableTriple<Double, Vec3, Integer>> interim,
+            @Local(argsOnly = true) TagKey<Fluid> fluidTag, @Local(ordinal = 1) LocalBooleanRef bl2
+    ) {
         interim.set(interimCalcs.get().computeIfAbsent(fluidTypeRef.get(), t -> MutableTriple.of(0.0, Vec3.ZERO, 0)));
         interim.get().setLeft(Math.max(a, interim.get().getLeft()));
+
+        bl2.set(kilt$isCorrectFluidTypeForTag(fluidTag, fluidTypeRef.get(), interimCalcs.get(), bl2.get()));
 
         return original.call(a, b);
     }
@@ -452,17 +462,6 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
     @ModifyExpressionValue(method = "updateFluidHeightAndDoFluidPushing", at = @At("MIXINEXTRAS:EXPRESSION"))
     private boolean kilt$checkIsPushedByFluid(boolean original, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef) {
         return this.isPushedByFluid(fluidTypeRef.get()) || original;
-    }
-
-    @Definition(id = "bl2", local = @Local(type = boolean.class, ordinal = 1))
-    @Expression("bl2 = @(true)")
-    @ModifyExpressionValue(method = "updateFluidHeightAndDoFluidPushing", at = @At("MIXINEXTRAS:EXPRESSION"))
-    private boolean kilt$makeSureIsInFluid(
-            boolean original, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef,
-            @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs,
-            @Local(argsOnly = true) TagKey<Fluid> fluidTag
-    ) {
-        return kilt$isCorrectFluidTypeForTag(fluidTag, fluidTypeRef.get(), interimCalcs.get(), original);
     }
 
     // Kilt: we don't need to handle d0 < 0.4D, that's already updated

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/EntityInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/EntityInject.java
@@ -294,12 +294,13 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
         return original.setSourcePos(pos);
     }
 
-    @Inject(method = "isEyeInFluid", at = @At("HEAD"), cancellable = true)
-    private void kilt$checkEyeInFluidType(TagKey<Fluid> fluidTag, CallbackInfoReturnable<Boolean> cir) {
+    @ModifyReturnValue(method = "isEyeInFluid", at = @At("RETURN"))
+    private boolean kilt$checkEyeInFluidType(boolean original, @Local(argsOnly = true) TagKey<Fluid> fluidTag) {
         if (fluidTag == FluidTags.WATER)
-            cir.setReturnValue(this.isEyeInFluidType(ForgeMod.WATER_TYPE.get()));
+            return this.isEyeInFluidType(ForgeMod.WATER_TYPE.get());
         else if (fluidTag == FluidTags.LAVA)
-            cir.setReturnValue(this.isEyeInFluidType(ForgeMod.LAVA_TYPE.get()));
+            return this.isEyeInFluidType(ForgeMod.LAVA_TYPE.get());
+        return original;
     }
 
     @Definition(id = "fluidHeight", field = "Lnet/minecraft/world/entity/Entity;fluidHeight:Lit/unimi/dsi/fastutil/objects/Object2DoubleMap;")
@@ -475,7 +476,7 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
     }
 
     @Inject(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;length()D", ordinal = 0), cancellable = true)
-    private void kilt$useInterimValuesForCalc(TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir, @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs) {
+    private void kilt$useInterimValuesForCalc(TagKey<Fluid> fluidTag, double motionScale, CallbackInfoReturnable<Boolean> cir, @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef) {
         if (interimCalcs.get().isEmpty() || (interimCalcs.get().size() == 1 && (interimCalcs.get().containsKey(ForgeMod.WATER_TYPE.get()) || interimCalcs.get().containsKey(ForgeMod.LAVA_TYPE.get())))) {
             interimCalcs.get().forEach((fluidType, interim) -> {
                 this.setFluidTypeHeight(fluidType, interim.getLeft());
@@ -509,12 +510,19 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
             this.setFluidTypeHeight(fluidType, interim.getLeft());
         });
 
-        if (fluidTag == FluidTags.WATER)
-            cir.setReturnValue(this.isInFluidType(ForgeMod.WATER_TYPE.get()));
-        else if (fluidTag == FluidTags.LAVA)
-            cir.setReturnValue(this.isInFluidType(ForgeMod.LAVA_TYPE.get()));
-        else
-            cir.setReturnValue(false);
+        kilt$originalForCancelCheck = kilt$isCorrectFluidTypeForTag(
+                fluidTag, fluidTypeRef.get(), interimCalcs.get(), false
+        );
+
+        cir.setReturnValue(kilt$updateFluidHeightAndDoFluidPushingInterimCalcCheck$handleModdedReturnValue(fluidTag, motionScale));
+    }
+
+    @Unique
+    private boolean kilt$originalForCancelCheck = false;
+
+    @Unique
+    public boolean kilt$updateFluidHeightAndDoFluidPushingInterimCalcCheck$handleModdedReturnValue(TagKey<Fluid> fluidTag, double motionScale) {
+        return kilt$originalForCancelCheck;
     }
 
     @WrapWithCondition(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "INVOKE", target = "Lit/unimi/dsi/fastutil/objects/Object2DoubleMap;put(Ljava/lang/Object;D)D", remap = false))

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/EntityInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/EntityInject.java
@@ -453,6 +453,17 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
         return this.isPushedByFluid(fluidTypeRef.get()) || original;
     }
 
+    @Definition(id = "bl2", local = @Local(type = boolean.class, ordinal = 1))
+    @Expression("bl2 = @(true)")
+    @ModifyExpressionValue(method = "updateFluidHeightAndDoFluidPushing", at = @At("MIXINEXTRAS:EXPRESSION"))
+    private boolean kilt$makeSureIsInFluid(
+            boolean original, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef,
+            @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs,
+            @Local(argsOnly = true) TagKey<Fluid> fluidTag
+    ) {
+        return kilt$isCorrectFluidTypeForTag(fluidTag, fluidTypeRef.get(), interimCalcs.get(), original);
+    }
+
     // Kilt: we don't need to handle d0 < 0.4D, that's already updated
 
     @WrapOperation(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;add(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;", ordinal = 0))
@@ -512,11 +523,6 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
             return true;
 
         return kilt$isCorrectFluidTypeForTag(fluidTag, fluidTypeRef.get(), interimCalcs.get(), true);
-    }
-
-    @ModifyReturnValue(method = "updateFluidHeightAndDoFluidPushing", at = @At(value = "RETURN", ordinal = 1))
-    private boolean kilt$ensureIsActuallyInFluidType(boolean original, @Share(value = "fluidType", namespace = Kilt.MOD_ID) LocalRef<FluidType> fluidTypeRef, @Share(value = "interimCalcs", namespace = Kilt.MOD_ID) LocalRef<Object2ObjectMap<FluidType, MutableTriple<Double, Vec3, Integer>>> interimCalcs, @Local(argsOnly = true) TagKey<Fluid> fluidTag) {
-        return kilt$isCorrectFluidTypeForTag(fluidTag, fluidTypeRef.get(), interimCalcs.get(), original);
     }
 
     @Unique

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
@@ -2,6 +2,7 @@ package xyz.bluspring.kilt.loader.mixin.modifications
 
 import com.bawnorton.mixinsquared.TargetHandler
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue
+import com.llamalad7.mixinextras.injector.ModifyReturnValue
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation
 import com.llamalad7.mixinextras.sugar.Share
 import org.objectweb.asm.Type
@@ -254,6 +255,60 @@ object KiltMixinModifications {
                         "at" to listOf(at(
                             value = "INVOKE",
                             target = "Lnet/minecraft/server/level/ServerLevel;removeBlock(Lnet/minecraft/core/BlockPos;Z)Z"
+                        ))
+                    )
+                )
+            )
+        ),
+
+        // Fix mixins like TFCs EntityMixin::fixUpdateFluidPushingToTreatWaterLikeFluidsAsWater
+        ReplacedAnnotationsModifier(
+            owner = "net/minecraft/world/entity/Entity",
+            methods = listOf("updateFluidHeightAndDoFluidPushing(Lnet/minecraft/tags/TagKey;D)Z"),
+            variables = mapOf(
+                "at" to listOf(at(
+                    value = "RETURN"
+                )),
+                "cancellable" to true
+            ),
+            replaceWith = listOf(
+                createAnnotation(
+                    Inject::class.java, mapOf(
+                        "method" to listOf(
+                            "updateFluidHeightAndDoFluidPushing(Lnet/minecraft/tags/TagKey;D)Z",
+	                        $$"kilt$updateFluidHeightAndDoFluidPushingInterimCalcCheck$handleModdedReturnValue(Lnet/minecraft/tags/TagKey;D)Z"
+                        ),
+                        "at" to listOf(at(
+                            value = "RETURN"
+                        )),
+                        "cancellable" to true
+                    )
+                )
+            )
+        )
+    )
+
+    val MODIFY_RETURN_VALUE = register(
+        ModifyReturnValue::class.java,
+
+        // We don't want to discourage people from using ModifyReturnValue.
+        ReplacedAnnotationsModifier(
+            owner = "net/minecraft/world/entity/Entity",
+            methods = listOf("updateFluidHeightAndDoFluidPushing(Lnet/minecraft/tags/TagKey;D)Z"),
+            variables = mapOf(
+                "at" to listOf(at(
+                    value = "RETURN"
+                ))
+            ),
+            replaceWith = listOf(
+                createAnnotation(
+                    ModifyReturnValue::class.java, mapOf(
+                        "method" to listOf(
+                            "updateFluidHeightAndDoFluidPushing(Lnet/minecraft/tags/TagKey;D)Z",
+							$$"kilt$updateFluidHeightAndDoFluidPushingInterimCalcCheck$handleModdedReturnValue(Lnet/minecraft/tags/TagKey;D)Z"
+                        ),
+                        "at" to listOf(at(
+                            value = "RETURN"
                         ))
                     )
                 )


### PR DESCRIPTION
First off, this PR fixes the bug where striders die in lava when TFC is installed. Essentially, instead of doing a check in `@ModifyReturnValue` like we did before, I change the value of bl2 (the variable returned at the end) soon after whenever it's set to true (so the fluid type has already been added to `interimCalcs`). This should hopefully keep Kilt more robust to mods that use [`CallbackInfoReturnable::setReturnValue`](https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1.20.x/src/main/java/net/dries007/tfc/mixin/EntityMixin.java#L31) instead of `@ModifyReturnValue` here.

Also fixes a bug where salt and spring water don't act like water to mobs. I basically did a hack to make methods targeting the return of `updateFluidHeightAndDoFluidPushing` with a cancellable `@Inject` or a `@ModifyReturnValue`  also target a dummy method which is used to determine the cancelled return value from `kilt$useInterimValuesForCalc`. Unlike Fabric, any Forge mods targeting this method at return will always run after all the main logic.

I've already checked Valkyrien Skies, and it seems to work with this. Any other particular mods I should check?