### PR TITLE
Try to fix the cached size of `<clinit>` not matching the actual size of the linked list.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -22,6 +22,12 @@ object EnumExtensionLoader {
     val proxies = mutableMapOf<String, MutableMap<String, EnumParameters.FieldReference>>()
     val indexed = mutableMapOf<String, Int>()
 
+    private val insnListSizeField = InsnList::class.java.getDeclaredField("size")
+
+    init {
+        insnListSizeField.isAccessible = true
+    }
+
     private fun remapPrototype(prototype: EnumPrototype): EnumPrototype {
         return EnumPrototype(
             prototype.owningMod,
@@ -184,9 +190,7 @@ object EnumExtensionLoader {
             insn = insn.next
         }
         if (actualSize != -1 && notedSize != actualSize && index == actualSize) {
-            val sizeField = nodes.javaClass.getDeclaredField("size")
-            sizeField.isAccessible = true
-            sizeField.set(nodes, actualSize)
+            insnListSizeField.set(nodes, actualSize)
         }
     }
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -171,11 +171,33 @@ object EnumExtensionLoader {
         }
     }
 
+    private fun fixSize(nodes: InsnList) {
+        val notedSize = nodes.size()
+        var index = 0
+        var actualSize = -1
+        var insn = nodes.first
+        while (insn != null) {
+            index++
+            if (insn == nodes.last) {
+                actualSize = index
+            }
+            insn = insn.next
+        }
+        if (actualSize != -1 && notedSize != actualSize && index == actualSize) {
+            val sizeField = nodes.javaClass.getDeclaredField("size")
+            sizeField.isAccessible = true
+            sizeField.set(nodes, actualSize)
+        }
+    }
+
     fun postApplyEnum(targetClass: ClassNode, mixinClass: ClassNode) {
         if (mixinClass.interfaces.contains(EXTENSIBLE_ENUM)) {
             val clinit = targetClass.methods.first { it.name == "<clinit>" }
 
             val vanillaCount = INITIAL_ENUM_COUNTS.getOrDefault(targetClass.name, 0)
+
+            // Fix ArrayIndexOutOfBoundsException exceptions because the cached size does not match the size of the linked list.
+            fixSize(clinit.instructions)
 
             // Make sure the ordinal parameter does not change between reboots.
             let {

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -22,10 +22,8 @@ object EnumExtensionLoader {
     val proxies = mutableMapOf<String, MutableMap<String, EnumParameters.FieldReference>>()
     val indexed = mutableMapOf<String, Int>()
 
-    private val insnListSizeField = InsnList::class.java.getDeclaredField("size")
-
-    init {
-        insnListSizeField.isAccessible = true
+    private val insnListSizeField = InsnList::class.java.getDeclaredField("size").apply {
+        isAccessible = true
     }
 
     private fun remapPrototype(prototype: EnumPrototype): EnumPrototype {


### PR DESCRIPTION
For some reason the size is sometimes too small, which throws an ArrayIndexOutOfBoundsException.