### PR TITLE
Added LivingEntity bed injects.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/injects/world/entity/LivingEntityInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/world/entity/LivingEntityInject.java
@@ -17,7 +17,6 @@ import com.llamalad7.mixinextras.sugar.ref.LocalDoubleRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalFloatRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.particles.ParticleOptions;
@@ -37,16 +36,11 @@ import net.minecraft.world.entity.animal.Pig;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.Property;
 import net.neoforged.neoforge.common.*;
 import net.neoforged.neoforge.common.damagesource.DamageContainer;
-import net.neoforged.neoforge.common.extensions.IBlockExtension;
 import net.neoforged.neoforge.common.extensions.ILivingEntityExtension;
 import net.neoforged.neoforge.event.EventHooks;
 import net.neoforged.neoforge.event.entity.living.EffectParticleModificationEvent;
@@ -651,104 +645,12 @@ public abstract class LivingEntityInject extends Entity implements ILivingEntity
         return original && !this.useItem.canPerformAction(ItemAbilities.SHIELD_BLOCK);
     }
 
-    @WrapOperation(
-        method = {"startSleeping", "method_18404"},
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/state/BlockState;setValue(Lnet/minecraft/world/level/block/state/properties/Property;Ljava/lang/Comparable;)Ljava/lang/Object;"
-        ),
-        expect = 2
-    )
-    private Object kilt$setBedOccupied(
-        BlockState blockState, Property<?> property, Comparable<?> comparable, Operation<Object> original,
-        @Share("occupied") LocalRef<Boolean> occupied
-    ) {
-        if (KiltHelper.INSTANCE.hasMethodOverride(
-            blockState.getBlock().getClass(), IBlockExtension.class, "setBedOccupied",
-            BlockState.class, Level.class, BlockPos.class, LivingEntity.class, Boolean.TYPE
-        )) {
-            // If mods override setBedOccupied they might not have the OCCUPIED block state, so early exit to avoid an exception.
-            occupied.set((Boolean) comparable);
-            return blockState;
-        } else {
-            occupied.set(null);
-        }
-        return original.call(blockState, property, comparable);
-    }
-
-    @WrapOperation(
-        method = {"startSleeping", "method_18404"},
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/Level;setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Z"
-        ),
-        expect = 2
-    )
-    private boolean kilt$setBedOccupied(
-        Level level, BlockPos blockPos, BlockState blockState, int i, Operation<Boolean> original,
-        @Share("occupied") LocalRef<Boolean> occupied
-    ) {
-        if (occupied.get() != null) {
-            blockState.setBedOccupied(level, blockPos, (LivingEntity) (Object) this, occupied.get());
-            return true;
-        }
-        return original.call(level, blockPos, blockState, i);
-    }
-
-    @Definition(id = "BedBlock", type = BedBlock.class)
-    @Expression("? instanceof BedBlock")
-    @WrapOperation(
-        method = {"method_18405", "method_18404", "startSleeping"},
-        at = @At("MIXINEXTRAS:EXPRESSION"),
-        expect = 3
-    )
-    private boolean kilt$isBed(
-        Object object, Operation<Boolean> original, @Local(argsOnly = true) BlockPos blockPos
-    ) {
-        if (KiltHelper.INSTANCE.hasMethodOverride(
-            object.getClass(), IBlockExtension.class, "isBed",
-            BlockState.class, BlockGetter.class, BlockPos.class, LivingEntity.class
-        )) {
-            return ((IBlockExtension) object).isBed(
-                this.level().getBlockState(blockPos),
-                this.level(), blockPos, (LivingEntity) (Object) this
-            );
-        }
-        return original.call(object);
-    }
+    // The rest of the bed checks are implemented via Fabric API.
 
     @WrapMethod(method = "checkBedExists")
     private boolean kilt$checkBedExists(Operation<Boolean> original) {
         boolean hasBed = original.call();
         return EventHooks.canEntityContinueSleeping((LivingEntity) (Object) this, hasBed ? null : Player.BedSleepingProblem.NOT_POSSIBLE_NOW);
-    }
-
-    @WrapOperation(
-        method = "getBedOrientation",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/BedBlock;getBedOrientation(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/Direction;"
-        )
-    )
-    private Direction kilt$getBedOrientation(BlockGetter blockGetter, BlockPos blockPos, Operation<Direction> original) {
-        var state = blockGetter.getBlockState(blockPos);
-        //noinspection ConstantValue
-        if (
-            (
-                KiltHelper.INSTANCE.hasMethodOverride(
-                    state.getBlock().getClass(), IBlockExtension.class, "getBedDirection",
-                    BlockState.class, LevelReader.class, BlockPos.class
-                ) || // If bed is not BebBlock we need to run the NeoForge getBedDirection for the correct result even if not overriden.
-                KiltHelper.INSTANCE.hasMethodOverride(
-                    state.getBlock().getClass(), IBlockExtension.class, "isBed",
-                    BlockState.class, BlockGetter.class, BlockPos.class, LivingEntity.class
-                )
-            ) &&
-            state.isBed(blockGetter, blockPos, (LivingEntity) (Object) this)
-        ) {
-            return state.getBedDirection(blockGetter instanceof LevelReader reader ? reader : level(), blockPos);
-        }
-        return original.call(blockGetter, blockPos);
     }
 
     @ModifyReturnValue(method = "getProjectile", at = @At("RETURN"))

--- a/src/main/java/xyz/bluspring/kilt/injects/world/entity/LivingEntityInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/world/entity/LivingEntityInject.java
@@ -647,9 +647,8 @@ public abstract class LivingEntityInject extends Entity implements ILivingEntity
 
     // The rest of the bed checks are implemented via Fabric API.
 
-    @WrapMethod(method = "checkBedExists")
-    private boolean kilt$checkBedExists(Operation<Boolean> original) {
-        boolean hasBed = original.call();
+    @ModifyReturnValue(method = "checkBedExists", at = @At("RETURN"))
+    private boolean kilt$checkBedExists(boolean hasBed) {
         return EventHooks.canEntityContinueSleeping((LivingEntity) (Object) this, hasBed ? null : Player.BedSleepingProblem.NOT_POSSIBLE_NOW);
     }
 

--- a/src/main/java/xyz/bluspring/kilt/injects/world/entity/LivingEntityInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/world/entity/LivingEntityInject.java
@@ -1,20 +1,12 @@
 // TRACKED HASH: 0103ffc8bca3b91dd898021eb13bdca66921d3eb
 package xyz.bluspring.kilt.injects.world.entity;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Stack;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
-
 import com.llamalad7.mixinextras.expression.Definition;
 import com.llamalad7.mixinextras.expression.Expression;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Cancellable;
@@ -24,35 +16,8 @@ import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalDoubleRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalFloatRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
-import net.neoforged.neoforge.common.CommonHooks;
-import net.neoforged.neoforge.common.EffectCure;
-import net.neoforged.neoforge.common.EffectCures;
-import net.neoforged.neoforge.common.ItemAbilities;
-import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.common.NeoForgeMod;
-import net.neoforged.neoforge.common.damagesource.DamageContainer;
-import net.neoforged.neoforge.common.extensions.ILivingEntityExtension;
-import net.neoforged.neoforge.event.EventHooks;
-import net.neoforged.neoforge.event.entity.living.EffectParticleModificationEvent;
-import net.neoforged.neoforge.event.entity.living.LivingShieldBlockEvent;
-import net.neoforged.neoforge.event.entity.living.LivingSwapItemsEvent;
-import net.neoforged.neoforge.event.entity.living.MobEffectEvent;
-import org.jetbrains.annotations.Nullable;
-import org.objectweb.asm.Opcodes;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import xyz.bluspring.kilt.injections.world.entity.LivingEntityInjection;
-import xyz.bluspring.kilt.util.KiltHelper;
-
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.particles.ParticleOptions;
@@ -72,9 +37,37 @@ import net.minecraft.world.entity.animal.Pig;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+import net.neoforged.neoforge.common.*;
+import net.neoforged.neoforge.common.damagesource.DamageContainer;
+import net.neoforged.neoforge.common.extensions.IBlockExtension;
+import net.neoforged.neoforge.common.extensions.ILivingEntityExtension;
+import net.neoforged.neoforge.event.EventHooks;
+import net.neoforged.neoforge.event.entity.living.EffectParticleModificationEvent;
+import net.neoforged.neoforge.event.entity.living.LivingShieldBlockEvent;
+import net.neoforged.neoforge.event.entity.living.LivingSwapItemsEvent;
+import net.neoforged.neoforge.event.entity.living.MobEffectEvent;
+import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.bluspring.kilt.injections.world.entity.LivingEntityInjection;
+import xyz.bluspring.kilt.util.KiltHelper;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityInject extends Entity implements ILivingEntityExtension, LivingEntityInjection {
@@ -658,7 +651,105 @@ public abstract class LivingEntityInject extends Entity implements ILivingEntity
         return original && !this.useItem.canPerformAction(ItemAbilities.SHIELD_BLOCK);
     }
 
-    // TODO: bed checks
+    @WrapOperation(
+        method = {"startSleeping", "method_18404"},
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/block/state/BlockState;setValue(Lnet/minecraft/world/level/block/state/properties/Property;Ljava/lang/Comparable;)Ljava/lang/Object;"
+        ),
+        expect = 2
+    )
+    private Object kilt$setBedOccupied(
+        BlockState blockState, Property<?> property, Comparable<?> comparable, Operation<Object> original,
+        @Share("occupied") LocalRef<Boolean> occupied
+    ) {
+        if (KiltHelper.INSTANCE.hasMethodOverride(
+            blockState.getBlock().getClass(), IBlockExtension.class, "setBedOccupied",
+            BlockState.class, Level.class, BlockPos.class, LivingEntity.class, Boolean.TYPE
+        )) {
+            // If mods override setBedOccupied they might not have the OCCUPIED block state, so early exit to avoid an exception.
+            occupied.set((Boolean) comparable);
+            return blockState;
+        } else {
+            occupied.set(null);
+        }
+        return original.call(blockState, property, comparable);
+    }
+
+    @WrapOperation(
+        method = {"startSleeping", "method_18404"},
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/Level;setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Z"
+        ),
+        expect = 2
+    )
+    private boolean kilt$setBedOccupied(
+        Level level, BlockPos blockPos, BlockState blockState, int i, Operation<Boolean> original,
+        @Share("occupied") LocalRef<Boolean> occupied
+    ) {
+        if (occupied.get() != null) {
+            blockState.setBedOccupied(level, blockPos, (LivingEntity) (Object) this, occupied.get());
+            return true;
+        }
+        return original.call(level, blockPos, blockState, i);
+    }
+
+    @Definition(id = "BedBlock", type = BedBlock.class)
+    @Expression("? instanceof BedBlock")
+    @WrapOperation(
+        method = {"method_18405", "method_18404", "startSleeping"},
+        at = @At("MIXINEXTRAS:EXPRESSION"),
+        expect = 3
+    )
+    private boolean kilt$isBed(
+        Object object, Operation<Boolean> original, @Local(argsOnly = true) BlockPos blockPos
+    ) {
+        if (KiltHelper.INSTANCE.hasMethodOverride(
+            object.getClass(), IBlockExtension.class, "isBed",
+            BlockState.class, BlockGetter.class, BlockPos.class, LivingEntity.class
+        )) {
+            return ((IBlockExtension) object).isBed(
+                this.level().getBlockState(blockPos),
+                this.level(), blockPos, (LivingEntity) (Object) this
+            );
+        }
+        return original.call(object);
+    }
+
+    @WrapMethod(method = "checkBedExists")
+    private boolean kilt$checkBedExists(Operation<Boolean> original) {
+        boolean hasBed = original.call();
+        return EventHooks.canEntityContinueSleeping((LivingEntity) (Object) this, hasBed ? null : Player.BedSleepingProblem.NOT_POSSIBLE_NOW);
+    }
+
+    @WrapOperation(
+        method = "getBedOrientation",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/block/BedBlock;getBedOrientation(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/Direction;"
+        )
+    )
+    private Direction kilt$getBedOrientation(BlockGetter blockGetter, BlockPos blockPos, Operation<Direction> original) {
+        var state = blockGetter.getBlockState(blockPos);
+        //noinspection ConstantValue
+        if (
+            (
+                KiltHelper.INSTANCE.hasMethodOverride(
+                    state.getBlock().getClass(), IBlockExtension.class, "getBedDirection",
+                    BlockState.class, LevelReader.class, BlockPos.class
+                ) || // If bed is not BebBlock we need to run the NeoForge getBedDirection for the correct result even if not overriden.
+                KiltHelper.INSTANCE.hasMethodOverride(
+                    state.getBlock().getClass(), IBlockExtension.class, "isBed",
+                    BlockState.class, BlockGetter.class, BlockPos.class, LivingEntity.class
+                )
+            ) &&
+            state.isBed(blockGetter, blockPos, (LivingEntity) (Object) this)
+        ) {
+            return state.getBedDirection(blockGetter instanceof LevelReader reader ? reader : level(), blockPos);
+        }
+        return original.call(blockGetter, blockPos);
+    }
 
     @ModifyReturnValue(method = "getProjectile", at = @At("RETURN"))
     private ItemStack kilt$tryGetProjectileStack(ItemStack original, @Local(argsOnly = true) ItemStack weapon) {

--- a/src/main/kotlin/xyz/bluspring/kilt/Kilt.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/Kilt.kt
@@ -14,12 +14,20 @@ import net.fabricmc.fabric.api.entity.event.v1.EntitySleepEvents
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents
+import net.minecraft.core.BlockPos
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.util.Unit
+import net.minecraft.world.InteractionResult
 import net.minecraft.world.entity.EquipmentSlot
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.level.BlockGetter
+import net.minecraft.world.level.Level
+import net.minecraft.world.level.LevelReader
+import net.minecraft.world.level.block.state.BlockState
 import net.neoforged.neoforge.common.CommonHooks
 import net.neoforged.neoforge.common.NeoForge
+import net.neoforged.neoforge.common.extensions.IBlockExtension
 import net.neoforged.neoforge.event.EventHooks
 import net.neoforged.neoforge.event.level.LevelEvent
 import net.neoforged.neoforge.server.ServerLifecycleHooks
@@ -29,6 +37,7 @@ import xyz.bluspring.kilt.client.KiltClient
 import xyz.bluspring.kilt.loader.KiltLoader
 import xyz.bluspring.kilt.mixin.MinecraftServerAccessor
 import xyz.bluspring.kilt.util.KiltHelper
+import xyz.bluspring.kilt.util.KiltHelper.hasMethodOverride
 
 class Kilt : ModInitializer {
     override fun onInitialize() {
@@ -104,6 +113,57 @@ class Kilt : ModInitializer {
                 return@register null
 
             EventHooks.canPlayerStartSleeping(player, pos, Either.right(Unit.INSTANCE)).left().orElse(null)
+        }
+
+        EntitySleepEvents.SET_BED_OCCUPATION_STATE.register { entity, pos, state, occupied ->
+            if (
+                hasMethodOverride(
+                    state.block.javaClass, IBlockExtension::class.java, "setBedOccupied",
+                    BlockState::class.java, Level::class.java, BlockPos::class.java,
+                    LivingEntity::class.java, Boolean::class.javaPrimitiveType!!
+                )
+            ) {
+                state.setBedOccupied(entity.level(), pos, entity, occupied)
+                return@register true
+            } else {
+                return@register false
+            }
+        }
+
+        EntitySleepEvents.ALLOW_BED.register { entity, pos, state, bool ->
+            if (
+                hasMethodOverride(
+                    state.block.javaClass, IBlockExtension::class.java, "isBed",
+                    BlockState::class.java, BlockGetter::class.java, BlockPos::class.java, LivingEntity::class.java
+                )
+            ) {
+                return@register if (state.isBed(entity.level(), pos, entity)) {
+                    InteractionResult.SUCCESS
+                } else {
+                    InteractionResult.FAIL
+                }
+            }
+            return@register InteractionResult.PASS
+        }
+
+        EntitySleepEvents.MODIFY_SLEEPING_DIRECTION.register { entity, pos, direction ->
+            val state: BlockState = entity.level().getBlockState(pos)
+            if (
+                (
+                    hasMethodOverride(
+                        state.block.javaClass, IBlockExtension::class.java, "getBedDirection",
+                        BlockState::class.java, LevelReader::class.java, BlockPos::class.java
+                    ) || // If bed is not BebBlock we need to run the NeoForge getBedDirection for the correct result even if not overriden.
+                    hasMethodOverride(
+                        state.block.javaClass, IBlockExtension::class.java, "isBed",
+                        BlockState::class.java, BlockGetter::class.java, BlockPos::class.java, LivingEntity::class.java
+                    )
+                ) &&
+                state.isBed(entity.level(), pos, entity)
+            ) {
+                return@register state.getBedDirection(entity.level(), pos)
+            }
+            return@register direction
         }
 
         EntitySleepEvents.ALLOW_SETTING_SPAWN.register { player, pos ->

--- a/src/main/kotlin/xyz/bluspring/kilt/Kilt.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/Kilt.kt
@@ -37,7 +37,6 @@ import xyz.bluspring.kilt.client.KiltClient
 import xyz.bluspring.kilt.loader.KiltLoader
 import xyz.bluspring.kilt.mixin.MinecraftServerAccessor
 import xyz.bluspring.kilt.util.KiltHelper
-import xyz.bluspring.kilt.util.KiltHelper.hasMethodOverride
 
 class Kilt : ModInitializer {
     override fun onInitialize() {
@@ -117,7 +116,7 @@ class Kilt : ModInitializer {
 
         EntitySleepEvents.SET_BED_OCCUPATION_STATE.register { entity, pos, state, occupied ->
             if (
-                hasMethodOverride(
+                KiltHelper.hasMethodOverride(
                     state.block.javaClass, IBlockExtension::class.java, "setBedOccupied",
                     BlockState::class.java, Level::class.java, BlockPos::class.java,
                     LivingEntity::class.java, Boolean::class.javaPrimitiveType!!
@@ -132,7 +131,7 @@ class Kilt : ModInitializer {
 
         EntitySleepEvents.ALLOW_BED.register { entity, pos, state, bool ->
             if (
-                hasMethodOverride(
+                KiltHelper.hasMethodOverride(
                     state.block.javaClass, IBlockExtension::class.java, "isBed",
                     BlockState::class.java, BlockGetter::class.java, BlockPos::class.java, LivingEntity::class.java
                 )
@@ -150,11 +149,11 @@ class Kilt : ModInitializer {
             val state: BlockState = entity.level().getBlockState(pos)
             if (
                 (
-                    hasMethodOverride(
+                    KiltHelper.hasMethodOverride(
                         state.block.javaClass, IBlockExtension::class.java, "getBedDirection",
                         BlockState::class.java, LevelReader::class.java, BlockPos::class.java
-                    ) || // If bed is not BebBlock we need to run the NeoForge getBedDirection for the correct result even if not overriden.
-                    hasMethodOverride(
+                    ) || // If bed is not BedBlock we need to run the NeoForge getBedDirection for the correct result even if not overridden.
+                    KiltHelper.hasMethodOverride(
                         state.block.javaClass, IBlockExtension::class.java, "isBed",
                         BlockState::class.java, BlockGetter::class.java, BlockPos::class.java, LivingEntity::class.java
                     )


### PR DESCRIPTION
This PR makes Kilt run `isBed`, `getBedDirection` and `setBedOccupied` checks for NeoForge blocks, as well as fire `CanContinueSleepingEvent` from LivingEntity.

This fixes a bug where straw beds in No Man's Land don't work.

Everything is handled via Fabric API, with the exception of CanContinueSleepingEvent which I added via mixin since I didn't feel that Fabric API had the specific event for it.

Let me know if you know any Fabric mods or other NeoForge mods that add custom beds to test this with.
I have not checked if `setBedOccupied` actually works because I don't know any mods for 1.21.1 that use it which also work at the moment.