### PR TITLE
Fix `EntityJoinLevelEvent` never being fired for non-player entities on the server side (and being fired twice for players).

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/injects/world/level/entity/PersistentEntitySectionManagerInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/world/level/entity/PersistentEntitySectionManagerInject.java
@@ -38,7 +38,7 @@ public abstract class PersistentEntitySectionManagerInject<T extends EntityAcces
 
     @Inject(method = "addEntity", at = @At("HEAD"), cancellable = true)
     private void kilt$callEntityJoinLevelEvent(T entity, boolean worldGenSpawned, CallbackInfoReturnable<Boolean> cir) {
-        if (this.kilt$callWithoutEvent.getAndSet(false) && entity instanceof Entity e && NeoForge.EVENT_BUS.post(new EntityJoinLevelEvent(e, e.level(), worldGenSpawned)).isCanceled())
+        if (!this.kilt$callWithoutEvent.getAndSet(false) && entity instanceof Entity e && NeoForge.EVENT_BUS.post(new EntityJoinLevelEvent(e, e.level(), worldGenSpawned)).isCanceled())
             cir.setReturnValue(false);
     }
 

--- a/src/main/java/xyz/bluspring/kilt/injects/world/level/entity/PersistentEntitySectionManagerInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/world/level/entity/PersistentEntitySectionManagerInject.java
@@ -38,6 +38,7 @@ public abstract class PersistentEntitySectionManagerInject<T extends EntityAcces
 
     @Inject(method = "addEntity", at = @At("HEAD"), cancellable = true)
     private void kilt$callEntityJoinLevelEvent(T entity, boolean worldGenSpawned, CallbackInfoReturnable<Boolean> cir) {
+        // Yes, this should in fact be inverted. We want the event to be fired when kilt$callWithoutEvent is set to false.
         if (!this.kilt$callWithoutEvent.getAndSet(false) && entity instanceof Entity e && NeoForge.EVENT_BUS.post(new EntityJoinLevelEvent(e, e.level(), worldGenSpawned)).isCanceled())
             cir.setReturnValue(false);
     }


### PR DESCRIPTION
Fixes the mob variant texture issues in No Man's Land.