### PR TITLE
Give NeoForge mods a module layer and access to scan data.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -675,6 +675,10 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
     fun loadMods() {
         Kilt.logger.info("Starting initialization of NeoForge mods...")
 
+        // Needed by Twilight Forest
+        FMLLoader.progressWindowTick = {}
+        FMLLoader.beforeStart(ModuleLayer.boot())
+
         val exception = RuntimeException("Failed to load NeoForge mods in Kilt!")
 
         // Initialize any compatibility bridges that have been registered


### PR DESCRIPTION
Also needed by Twilight Forest beanification.

Marking as draft since it also bumps the fml module.