### PR TITLE
Add registry aliases for NeoForge mods to the NeoForge alias map instead of the Fabric one.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/mixin/workarounds/mapped_registry_aliases/MappedRegistryMixin.java
+++ b/src/main/java/xyz/bluspring/kilt/mixin/workarounds/mapped_registry_aliases/MappedRegistryMixin.java
@@ -1,0 +1,44 @@
+package xyz.bluspring.kilt.mixin.workarounds.mapped_registry_aliases;
+
+import net.fabricmc.fabric.api.event.registry.FabricRegistry;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.BaseMappedRegistry;
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Intrinsic;
+import org.spongepowered.asm.mixin.Mixin;
+import xyz.bluspring.kilt.loader.KiltLoader;
+import xyz.bluspring.kilt.workarounds.MappedRegistryWorkaround;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+@SuppressWarnings("NonExtendableApiUsage")
+@Mixin(value = MappedRegistry.class, priority = 1050)
+@Implements(@Interface(iface = MappedRegistryWorkaround.class, prefix = "kilt$i$"))
+public class MappedRegistryMixin implements FabricRegistry {
+
+    @Intrinsic(displace = true)
+    public void kilt$i$addAlias(ResourceLocation old, ResourceLocation newId) {
+        if (KiltLoader.Companion.getInstance().hasMod(old.getNamespace())) {
+            try {
+                // https://stackoverflow.com/a/15674467
+                @SuppressWarnings("JavaLangInvokeHandleSignature")
+                MethodHandle super$addAlias = MethodHandles.lookup().findSpecial(
+                    BaseMappedRegistry.class, "addAlias",
+                    MethodType.methodType(Void.TYPE, ResourceLocation.class, ResourceLocation.class),
+                    MappedRegistry.class
+                );
+                //noinspection JavaLangInvokeHandleSignature
+                super$addAlias.invoke(this, old, newId);
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            addAlias(old, newId);
+        }
+    }
+
+}

--- a/src/main/java/xyz/bluspring/kilt/mixin/workarounds/mapped_registry_aliases/MappedRegistryMixin.java
+++ b/src/main/java/xyz/bluspring/kilt/mixin/workarounds/mapped_registry_aliases/MappedRegistryMixin.java
@@ -4,10 +4,7 @@ import net.fabricmc.fabric.api.event.registry.FabricRegistry;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.registries.BaseMappedRegistry;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Intrinsic;
-import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.*;
 import xyz.bluspring.kilt.loader.KiltLoader;
 import xyz.bluspring.kilt.workarounds.MappedRegistryWorkaround;
 
@@ -18,8 +15,9 @@ import java.lang.invoke.MethodType;
 @SuppressWarnings("NonExtendableApiUsage")
 @Mixin(value = MappedRegistry.class, priority = 1050)
 @Implements(@Interface(iface = MappedRegistryWorkaround.class, prefix = "kilt$i$"))
-public class MappedRegistryMixin implements FabricRegistry {
+public abstract class MappedRegistryMixin implements FabricRegistry {
 
+    @Unique
     private static final MethodHandle kilt$super$addAlias;
 
     static {

--- a/src/main/java/xyz/bluspring/kilt/mixin/workarounds/mapped_registry_aliases/MappedRegistryMixin.java
+++ b/src/main/java/xyz/bluspring/kilt/mixin/workarounds/mapped_registry_aliases/MappedRegistryMixin.java
@@ -20,19 +20,28 @@ import java.lang.invoke.MethodType;
 @Implements(@Interface(iface = MappedRegistryWorkaround.class, prefix = "kilt$i$"))
 public class MappedRegistryMixin implements FabricRegistry {
 
+    private static final MethodHandle kilt$super$addAlias;
+
+    static {
+        try {
+            // https://stackoverflow.com/a/15674467
+            //noinspection JavaLangInvokeHandleSignature
+            kilt$super$addAlias = MethodHandles.lookup().findSpecial(
+                BaseMappedRegistry.class, "addAlias",
+                MethodType.methodType(Void.TYPE, ResourceLocation.class, ResourceLocation.class),
+                MappedRegistry.class
+            );
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Intrinsic(displace = true)
     public void kilt$i$addAlias(ResourceLocation old, ResourceLocation newId) {
         if (KiltLoader.Companion.getInstance().hasMod(old.getNamespace())) {
             try {
-                // https://stackoverflow.com/a/15674467
-                @SuppressWarnings("JavaLangInvokeHandleSignature")
-                MethodHandle super$addAlias = MethodHandles.lookup().findSpecial(
-                    BaseMappedRegistry.class, "addAlias",
-                    MethodType.methodType(Void.TYPE, ResourceLocation.class, ResourceLocation.class),
-                    MappedRegistry.class
-                );
                 //noinspection JavaLangInvokeHandleSignature
-                super$addAlias.invoke(this, old, newId);
+                kilt$super$addAlias.invoke(this, old, newId);
             } catch (Throwable e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/xyz/bluspring/kilt/workarounds/MappedRegistryWorkaround.java
+++ b/src/main/java/xyz/bluspring/kilt/workarounds/MappedRegistryWorkaround.java
@@ -1,0 +1,9 @@
+package xyz.bluspring.kilt.workarounds;
+
+import net.minecraft.resources.ResourceLocation;
+
+public interface MappedRegistryWorkaround {
+
+    void addAlias(ResourceLocation old, ResourceLocation newId);
+
+}

--- a/src/main/resources/Kilt.mixins.json
+++ b/src/main/resources/Kilt.mixins.json
@@ -80,6 +80,7 @@
       "resources.RegistryOpsAccessor",
       "server.level.TicketAccessor",
       "workarounds.avoid_feature_cycles.BiomeGenerationSettings$PlainBuilderMixin",
+      "workarounds.mapped_registry_aliases.MappedRegistryMixin",
       "workarounds.method_remap_workaround.ICommonPacketListenerMixin",
       "workarounds.method_remap_workaround.MutableDataComponentHolderMixin",
       "workarounds.method_remap_workaround.ServerCommonPacketListenerImplMixin",


### PR DESCRIPTION
Otherwise, some items such as the Twilight Forest empty magic map are never registered.