### PR TITLE
Port method remapping fix from 1.20.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -72,7 +72,7 @@ eventbus_version = 8.0.5
 forgespi_version=7.1.3
 
 # custom fork - https://mvn.devos.one/#/snapshots/xyz/bluspring/AutoRenamingTool
-forgerenamer_version=0.1.52
+forgerenamer_version=0.1.54
 
 # custom fork - https://mvn.devos.one/#/snapshots/xyz/bluspring/srgutils
 srgutils_version = 0.5.15

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinRemapper.kt
@@ -430,13 +430,8 @@ object MixinRemapper {
                     for (methodOpt in currentClass.methods) {
                         val method = methodOpt.orElse(null) ?: continue
 
-                        if (method.name == member
-                            // makes sure that we're actually targeting the right place.
-                            && (
-                                method.toString().startsWith(target) ||
-                                method.toString().startsWith(currentClass.mapped)
-                            )
-                        ) {
+                        val declaringClass = method.declaringClass
+                        if (method.name == member && currentClass == declaringClass) {
                             // oh hey look, we found one
                             return "$mappedClassDescriptor${remapper.mapMethodName(target, method.name, method.descriptor)}${KiltRemapper.remapDescriptor(method.descriptor)}".breakpoint()
                         }


### PR DESCRIPTION
Ports the remapper fix from #748

Fixes [Blueprint's PlayerRendererMixin](https://github.com/team-abnormals/blueprint/blob/01258fce8f85d9eadc5455436287eb07b5e0a7c3/src/main/java/com/teamabnormals/blueprint/core/mixin/client/PlayerRendererMixin.java#L20) being remapped incorrectly in production.