### PR TITLE
Only load enum extensions for the mod defining them.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/EnumExtensionLoader.kt
@@ -39,6 +39,12 @@ object EnumExtensionLoader {
 
     fun loadEnumExtension(mod: NeoForgeMod) {
         mod.config.getConfigList("mods").forEach { config ->
+            // Prevent mods from loading enum extensions that aren't theirs.
+            val modId = config.getConfigElement<String>("modId")
+            if (modId.isEmpty || modId.get() != mod.modId) {
+                return@forEach
+            }
+
             config.getConfigElement<String>("enumExtensions").ifPresent { file ->
                 val path = mod.owningFile.getFile().findResource(file)
                 if (Files.isRegularFile(path)) {


### PR DESCRIPTION
Needed for Vampirism as otherwise it tries to load all enum extensions again for `teamlapenlib`.