### PR TITLE
Fix shrouded armor items still rendering on the player (Twilight Forest).

### DIFF
--- a/compat/forge-compats/build.gradle.kts
+++ b/compat/forge-compats/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     compileOnly("maven.modrinth:ldlib:${property("ldlib_version")}")
     modCompileOnly("maven.modrinth:creativecore:${property("creativecore_version")}")
     compileOnly("thedarkcolour:kfflang-neoforge:${property("kotlinforforge_version")}")
+    compileOnly("curse.maven:the-twilight-forest-227639:${property("twilightforest_version")}")
 }
 
 tasks {

--- a/compat/forge-compats/src/main/java/xyz/bluspring/kilt/compat/forge/mixin/twilightforest/ElytraLayerMixin.java
+++ b/compat/forge-compats/src/main/java/xyz/bluspring/kilt/compat/forge/mixin/twilightforest/ElytraLayerMixin.java
@@ -1,0 +1,30 @@
+package xyz.bluspring.kilt.compat.forge.mixin.twilightforest;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
+import net.minecraft.client.renderer.entity.layers.ElytraLayer;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import twilightforest.asmhooks.ArmorHooks;
+
+@IfModLoaded("twilightforest")
+@Mixin(ElytraLayer.class)
+public class ElytraLayerMixin {
+
+    // Re-implementation of https://github.com/TeamTwilight/twilightforest/blob/1.21.1/tf-asm/src/main/java/twilightforest/asm/transformers/armor/CancelElytraRenderingTransformer.java
+    @Definition(id = "itemStack", local = @Local(type = ItemStack.class))
+    @Definition(id = "is", method = "Lnet/minecraft/world/item/ItemStack;is(Lnet/minecraft/world/item/Item;)Z")
+    @Definition(id = "ELYTRA", field = "Lnet/minecraft/world/item/Items;ELYTRA:Lnet/minecraft/world/item/Item;")
+    @Expression("itemStack.is(ELYTRA)")
+    @WrapOperation(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V", at = @At("MIXINEXTRAS:EXPRESSION"))
+    public boolean kilt$twilightforest$render(ItemStack itemStack, Item item, Operation<Boolean> original) {
+        return ArmorHooks.cancelArmorRendering(original.call(itemStack, item), itemStack);
+    }
+
+}

--- a/compat/forge-compats/src/main/java/xyz/bluspring/kilt/compat/forge/mixin/twilightforest/HumanoidArmorLayerMixin.java
+++ b/compat/forge-compats/src/main/java/xyz/bluspring/kilt/compat/forge/mixin/twilightforest/HumanoidArmorLayerMixin.java
@@ -1,0 +1,30 @@
+package xyz.bluspring.kilt.compat.forge.mixin.twilightforest;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import twilightforest.asmhooks.ArmorHooks;
+
+@IfModLoaded("twilightforest")
+@Mixin(HumanoidArmorLayer.class)
+public class HumanoidArmorLayerMixin {
+
+    // Re-implementation of https://github.com/TeamTwilight/twilightforest/blob/1.21.1/tf-asm/src/main/java/twilightforest/asm/transformers/armor/CancelArmorRenderingTransformer.java
+    @Definition(id = "ArmorItem", type = ArmorItem.class)
+    @Expression("? instanceof ArmorItem")
+    @ModifyExpressionValue(
+        method = "renderArmorPiece",
+        at = @At("MIXINEXTRAS:EXPRESSION")
+    )
+    public boolean kilt$twilightforest$renderArmorPiece(boolean original, @Local ItemStack stack) {
+        return ArmorHooks.cancelArmorRendering(original, stack);
+    }
+
+}

--- a/compat/forge-compats/src/main/resources/kilt_forge_compats.mixins.json
+++ b/compat/forge-compats/src/main/resources/kilt_forge_compats.mixins.json
@@ -1,23 +1,25 @@
 {
-  "required": true,
-  "minVersion": "0.8",
-  "package": "xyz.bluspring.kilt.compat.forge.mixin",
-  "compatibilityLevel": "JAVA_17",
-  "mixins": [
-    "cyclopscore.MinecraftHelpersMixin",
-    "cyclopscore.ModBaseMixin",
-    "quark.ConcretePowderBlockMixin",
-    "structure_gel.StructureTemplateMixin",
-    "thirst.PotionItemMixin"
-  ],
-  "client": [
-    "quark.LevelRendererMixin"
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  },
-  "plugin": "xyz.bluspring.kilt.compat.forge.KiltForgeCompatMixinPlugin",
-  "mixinextras": {
-    "minVersion": "0.5.0-beta.5"
-  }
+    "required": true,
+    "minVersion": "0.8",
+    "package": "xyz.bluspring.kilt.compat.forge.mixin",
+    "compatibilityLevel": "JAVA_17",
+    "mixins": [
+        "cyclopscore.MinecraftHelpersMixin",
+        "cyclopscore.ModBaseMixin",
+        "quark.ConcretePowderBlockMixin",
+        "structure_gel.StructureTemplateMixin",
+        "thirst.PotionItemMixin"
+    ],
+    "client": [
+        "quark.LevelRendererMixin",
+        "twilightforest.ElytraLayerMixin",
+        "twilightforest.HumanoidArmorLayerMixin"
+    ],
+    "injectors": {
+        "defaultRequire": 1
+    },
+    "plugin": "xyz.bluspring.kilt.compat.forge.KiltForgeCompatMixinPlugin",
+    "mixinextras": {
+        "minVersion": "0.5.0-beta.5"
+	}
 }

--- a/compat/gradle.properties
+++ b/compat/gradle.properties
@@ -24,3 +24,5 @@ littletiles_version = 1.6.0-pre213
 creativecore_version = 2.13.29-fabric,1.21.1
 # https://github.com/thedarkcolour/KotlinForForge/tree/site/thedarkcolour/kfflang-neoforge
 kotlinforforge_version = 5.11.0
+# https://www.curseforge.com/minecraft/mc-mods/the-twilight-forest
+twilightforest_version = 7797302


### PR DESCRIPTION
Makes armour combined with Emperor's Cloth not render when equipped as intended.

Also decided to allow the .editorconfig to format the mixin config for the NeoForge compats module.