### PR TITLE
Also check method descriptor when remapping instructions targeting shadowed methods.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinShadowRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinShadowRemapper.kt
@@ -66,10 +66,12 @@ object MixinShadowRemapper {
         return remapped
     }
 
+    data class MethodReference(val name: String, val desc: String)
+
     private fun updateFieldsAndMethods(
         classNode: ClassNode, remapper: KiltEnhancedRemapper,
         remappedFields: MutableMap<String, String>,
-        remappedMethods: MutableMap<String, String>,
+        remappedMethods: MutableMap<MethodReference, String>,
         targetClassNames: Collection<String>,
         unmappedParentMixinLookup: Map<String, ClassNode>, renameNodes: Boolean,
     ) {
@@ -86,7 +88,7 @@ object MixinShadowRemapper {
         for (method in classNode.methods) {
             val remapped = remapMethod(method, remapper, targetClassNames) ?: continue
 
-            remappedMethods[method.name] = remapped
+            remappedMethods[MethodReference(method.name, method.desc)] = remapped
             if (renameNodes) {
                 method.name = remapped
             }
@@ -111,7 +113,7 @@ object MixinShadowRemapper {
 
     fun remapClass(classNode: ClassNode, remapper: KiltEnhancedRemapper, unmappedParentMixinLookup: Map<String, ClassNode>) {
         val remappedFields = mutableMapOf<String, String>()
-        val remappedMethods = mutableMapOf<String, String>()
+        val remappedMethods = mutableMapOf<MethodReference, String>()
         val targetClassNames = MixinRemapper.getMixinClassTargets(classNode)
 
         // Collect shadows in this class
@@ -124,7 +126,7 @@ object MixinShadowRemapper {
                     val remapped = remappedFields[insnNode.name] ?: continue
                     insnNode.name = remapped
                 } else if (insnNode is MethodInsnNode) {
-                    val remapped = remappedMethods[insnNode.name] ?: continue
+                    val remapped = remappedMethods[MethodReference(insnNode.name, insnNode.desc)] ?: continue
                     insnNode.name = remapped
                 } else if (insnNode is InvokeDynamicInsnNode) {
                     if ("metafactory" != insnNode.bsm.name)
@@ -141,7 +143,7 @@ object MixinShadowRemapper {
                             val lambdaTarget = insnNode.bsmArgs[1] as Handle
                             if (lambdaTarget.owner == classNode.name) {
                                 val handle = Handle(lambdaTarget.tag, lambdaTarget.owner,
-                                    remappedMethods[lambdaTarget.name] ?: continue,
+                                    remappedMethods[MethodReference(lambdaTarget.name, lambdaTarget.desc)] ?: continue,
                                     lambdaTarget.desc, lambdaTarget.isInterface
                                 )
 


### PR DESCRIPTION
Closes #814

I briefly considered doing the same thing for fields, but I don't think any Java compiler lets you put 2 fields with the same name in the same mixin.