### PR TITLE
Remove LootTable::getPools accessor modifier.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
@@ -326,14 +326,6 @@ object KiltMixinModifications {
             "kilt\$getItemColors"
         ),
         AccessorModifier(
-            "net/minecraft/world/level/storage/loot/LootTable",
-            listOf("getPools", "pools"),
-            "()Ljava/util/List;",
-
-            "xyz/bluspring/kilt/injections/world/level/storage/loot/LootTableInjection",
-            "kilt\$getPools"
-        ),
-        AccessorModifier(
             "net/minecraft/client/particle/ParticleEngine",
             listOf("getProviders", "providers"),
             "()Ljava/util/Map;",


### PR DESCRIPTION
We don't want this accessor modifier in 1.21.1 since NeoForge doesn't touch this field anymore.