### PR TITLE
Clear and re-bake on registry sync.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/injects/core/MappedRegistryInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/core/MappedRegistryInject.java
@@ -1,22 +1,16 @@
 // TRACKED HASH: 399562caae5944ef11e0759f3ce9d673134c41a2
 package xyz.bluspring.kilt.injects.core;
 
-import java.util.HashSet;
 import java.util.Map;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
-import com.mojang.serialization.Lifecycle;
 import it.unimi.dsi.fastutil.objects.ObjectList;
 import it.unimi.dsi.fastutil.objects.Reference2IntMap;
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
 import net.neoforged.neoforge.registries.BaseMappedRegistry;
 import net.neoforged.neoforge.registries.IRegistryExtension;
-import net.neoforged.neoforge.registries.RegistryManager;
-import net.neoforged.neoforge.registries.RegistrySnapshot;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -25,9 +19,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import xyz.bluspring.kilt.Kilt;
 import xyz.bluspring.kilt.helpers.mixin.Extends;
 import xyz.bluspring.kilt.injections.core.MappedRegistryInjection;
 
@@ -40,7 +32,6 @@ import net.minecraft.core.WritableRegistry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import xyz.bluspring.kilt.loader.KiltLoader;
 
 @Extends(BaseMappedRegistry.class)
 @Mixin(MappedRegistry.class)
@@ -61,25 +52,6 @@ public abstract class MappedRegistryInject<T> implements MappedRegistryInjection
     @Shadow
     private boolean frozen;
     @Unique private final ThreadLocal<Integer> kilt$id = new ThreadLocal<>();
-
-    @Unique
-    private static final ResourceLocation KILT$APPLY_SNAPSHOT_PHASE = ResourceLocation.fromNamespaceAndPath(Kilt.MOD_ID, "apply_snapshot");
-
-    @Inject(
-        method = "<init>(Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Lifecycle;Z)V",
-        at = @At("RETURN"),
-        order = 1050
-    )
-    private void kilt$init(ResourceKey<?> key, Lifecycle registryLifecycle, boolean hasIntrusiveHolders, CallbackInfo ci) {
-        var namespace = key.location().getNamespace();
-        if (namespace.equals(ResourceLocation.DEFAULT_NAMESPACE) || KiltLoader.Companion.getInstance().hasMod(namespace)) {
-            var idRemapEvent = RegistryIdRemapCallback.event(this);
-            idRemapEvent.addPhaseOrdering(Event.DEFAULT_PHASE, KILT$APPLY_SNAPSHOT_PHASE);
-            idRemapEvent.register(KILT$APPLY_SNAPSHOT_PHASE, state -> {
-                RegistryManager.applySnapshot((MappedRegistry<?>) (Object) this, new RegistrySnapshot(this, false), new HashSet<>());
-            });
-        }
-    }
 
     @Override
     public Holder.Reference<T> register(int id, ResourceKey<T> key, T value, RegistrationInfo info) {

--- a/src/main/java/xyz/bluspring/kilt/injects/core/MappedRegistryInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/core/MappedRegistryInject.java
@@ -1,16 +1,22 @@
 // TRACKED HASH: 399562caae5944ef11e0759f3ce9d673134c41a2
 package xyz.bluspring.kilt.injects.core;
 
+import java.util.HashSet;
 import java.util.Map;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import com.mojang.serialization.Lifecycle;
 import it.unimi.dsi.fastutil.objects.ObjectList;
 import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
 import net.neoforged.neoforge.registries.BaseMappedRegistry;
 import net.neoforged.neoforge.registries.IRegistryExtension;
+import net.neoforged.neoforge.registries.RegistryManager;
+import net.neoforged.neoforge.registries.RegistrySnapshot;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -19,7 +25,9 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.bluspring.kilt.Kilt;
 import xyz.bluspring.kilt.helpers.mixin.Extends;
 import xyz.bluspring.kilt.injections.core.MappedRegistryInjection;
 
@@ -32,6 +40,7 @@ import net.minecraft.core.WritableRegistry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
+import xyz.bluspring.kilt.loader.KiltLoader;
 
 @Extends(BaseMappedRegistry.class)
 @Mixin(MappedRegistry.class)
@@ -52,6 +61,25 @@ public abstract class MappedRegistryInject<T> implements MappedRegistryInjection
     @Shadow
     private boolean frozen;
     @Unique private final ThreadLocal<Integer> kilt$id = new ThreadLocal<>();
+
+    @Unique
+    private static final ResourceLocation KILT$APPLY_SNAPSHOT_PHASE = ResourceLocation.fromNamespaceAndPath(Kilt.MOD_ID, "apply_snapshot");
+
+    @Inject(
+        method = "<init>(Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Lifecycle;Z)V",
+        at = @At("RETURN"),
+        order = 1050
+    )
+    private void kilt$init(ResourceKey<?> key, Lifecycle registryLifecycle, boolean hasIntrusiveHolders, CallbackInfo ci) {
+        var namespace = key.location().getNamespace();
+        if (namespace.equals(ResourceLocation.DEFAULT_NAMESPACE) || KiltLoader.Companion.getInstance().hasMod(namespace)) {
+            var idRemapEvent = RegistryIdRemapCallback.event(this);
+            idRemapEvent.addPhaseOrdering(Event.DEFAULT_PHASE, KILT$APPLY_SNAPSHOT_PHASE);
+            idRemapEvent.register(KILT$APPLY_SNAPSHOT_PHASE, state -> {
+                RegistryManager.applySnapshot((MappedRegistry<?>) (Object) this, new RegistrySnapshot(this, false), new HashSet<>());
+            });
+        }
+    }
 
     @Override
     public Holder.Reference<T> register(int id, ResourceKey<T> key, T value, RegistrationInfo info) {

--- a/src/main/java/xyz/bluspring/kilt/mixin/workarounds/registry_clear/MappedRegistryMixin.java
+++ b/src/main/java/xyz/bluspring/kilt/mixin/workarounds/registry_clear/MappedRegistryMixin.java
@@ -1,0 +1,44 @@
+package xyz.bluspring.kilt.mixin.workarounds.registry_clear;
+
+import com.mojang.serialization.Lifecycle;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.registry.RegistryIdRemapCallback;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.RegistryManager;
+import net.neoforged.neoforge.registries.RegistrySnapshot;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import xyz.bluspring.kilt.Kilt;
+import xyz.bluspring.kilt.loader.KiltLoader;
+
+import java.util.HashSet;
+
+@Mixin(MappedRegistry.class)
+public abstract class MappedRegistryMixin<T> implements Registry<T> {
+
+    @Unique
+    private static final ResourceLocation KILT$APPLY_SNAPSHOT_PHASE = ResourceLocation.fromNamespaceAndPath(Kilt.MOD_ID, "apply_snapshot");
+
+    @Inject(
+        method = "<init>(Lnet/minecraft/resources/ResourceKey;Lcom/mojang/serialization/Lifecycle;Z)V",
+        at = @At("RETURN"),
+        order = 1050
+    )
+    private void kilt$applySnapshot(ResourceKey<?> key, Lifecycle registryLifecycle, boolean hasIntrusiveHolders, CallbackInfo ci) {
+        var namespace = key.location().getNamespace();
+        if (namespace.equals(ResourceLocation.DEFAULT_NAMESPACE) || KiltLoader.Companion.getInstance().hasMod(namespace)) {
+            var idRemapEvent = RegistryIdRemapCallback.event(this);
+            idRemapEvent.addPhaseOrdering(Event.DEFAULT_PHASE, KILT$APPLY_SNAPSHOT_PHASE);
+            idRemapEvent.register(KILT$APPLY_SNAPSHOT_PHASE, state -> {
+                RegistryManager.applySnapshot((MappedRegistry<?>) (Object) this, new RegistrySnapshot(this, false), new HashSet<>());
+            });
+        }
+    }
+
+}

--- a/src/main/java/xyz/bluspring/kilt/mixin/workarounds/registry_clear/MappedRegistryMixin.java
+++ b/src/main/java/xyz/bluspring/kilt/mixin/workarounds/registry_clear/MappedRegistryMixin.java
@@ -7,8 +7,7 @@ import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.neoforge.registries.RegistryManager;
-import net.neoforged.neoforge.registries.RegistrySnapshot;
+import net.neoforged.neoforge.registries.BaseMappedRegistry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -16,9 +15,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.bluspring.kilt.Kilt;
 import xyz.bluspring.kilt.injections.core.MappedRegistryInjection;
-import xyz.bluspring.kilt.loader.KiltLoader;
-
-import java.util.HashSet;
 
 @Mixin(MappedRegistry.class)
 public abstract class MappedRegistryMixin<T> implements Registry<T>, MappedRegistryInjection<T> {
@@ -31,23 +27,13 @@ public abstract class MappedRegistryMixin<T> implements Registry<T>, MappedRegis
         at = @At("RETURN"),
         order = 1050
     )
-    private void kilt$applySnapshot(ResourceKey<? extends Registry<T>> key, Lifecycle registryLifecycle, boolean hasIntrusiveHolders, CallbackInfo ci) {
-        var namespace = key.location().getNamespace();
-        if (namespace.equals(ResourceLocation.DEFAULT_NAMESPACE) || KiltLoader.Companion.getInstance().hasMod(namespace)) {
-            var idRemapEvent = RegistryIdRemapCallback.event(this);
-            idRemapEvent.addPhaseOrdering(Event.DEFAULT_PHASE, KILT$APPLY_SNAPSHOT_PHASE);
-            idRemapEvent.register(KILT$APPLY_SNAPSHOT_PHASE, state -> {
-                this.unfreeze();
-                var snapshot = new RegistrySnapshot(this, false);
-                this.clear(false);
-                snapshot.getAliases().forEach(this::addAlias);
-                for (int id : snapshot.getIds().keySet()) {
-                    ResourceKey<T> idKey = ResourceKey.create(key, snapshot.getIds().get(id));
-                    registerIdMapping(idKey, id);
-                }
-                this.freeze();
-            });
-        }
+    private void kilt$initClearBakeBridge(ResourceKey<? extends Registry<T>> key, Lifecycle registryLifecycle, boolean hasIntrusiveHolders, CallbackInfo ci) {
+        var idRemapEvent = RegistryIdRemapCallback.event(this);
+        idRemapEvent.addPhaseOrdering(Event.DEFAULT_PHASE, KILT$APPLY_SNAPSHOT_PHASE);
+        idRemapEvent.register(KILT$APPLY_SNAPSHOT_PHASE, state -> {
+            ((BaseMappedRegistry<T>) (Object) this).clearCallbacks.forEach(callback -> callback.onClear(this, false));
+            ((BaseMappedRegistry<T>) (Object) this).bakeCallbacks.forEach(callback -> callback.onBake(this));
+        });
     }
 
 }

--- a/src/main/java/xyz/bluspring/kilt/mixin/workarounds/registry_clear/MappedRegistryMixin.java
+++ b/src/main/java/xyz/bluspring/kilt/mixin/workarounds/registry_clear/MappedRegistryMixin.java
@@ -15,12 +15,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.bluspring.kilt.Kilt;
+import xyz.bluspring.kilt.injections.core.MappedRegistryInjection;
 import xyz.bluspring.kilt.loader.KiltLoader;
 
 import java.util.HashSet;
 
 @Mixin(MappedRegistry.class)
-public abstract class MappedRegistryMixin<T> implements Registry<T> {
+public abstract class MappedRegistryMixin<T> implements Registry<T>, MappedRegistryInjection<T> {
 
     @Unique
     private static final ResourceLocation KILT$APPLY_SNAPSHOT_PHASE = ResourceLocation.fromNamespaceAndPath(Kilt.MOD_ID, "apply_snapshot");
@@ -30,13 +31,21 @@ public abstract class MappedRegistryMixin<T> implements Registry<T> {
         at = @At("RETURN"),
         order = 1050
     )
-    private void kilt$applySnapshot(ResourceKey<?> key, Lifecycle registryLifecycle, boolean hasIntrusiveHolders, CallbackInfo ci) {
+    private void kilt$applySnapshot(ResourceKey<? extends Registry<T>> key, Lifecycle registryLifecycle, boolean hasIntrusiveHolders, CallbackInfo ci) {
         var namespace = key.location().getNamespace();
         if (namespace.equals(ResourceLocation.DEFAULT_NAMESPACE) || KiltLoader.Companion.getInstance().hasMod(namespace)) {
             var idRemapEvent = RegistryIdRemapCallback.event(this);
             idRemapEvent.addPhaseOrdering(Event.DEFAULT_PHASE, KILT$APPLY_SNAPSHOT_PHASE);
             idRemapEvent.register(KILT$APPLY_SNAPSHOT_PHASE, state -> {
-                RegistryManager.applySnapshot((MappedRegistry<?>) (Object) this, new RegistrySnapshot(this, false), new HashSet<>());
+                this.unfreeze();
+                var snapshot = new RegistrySnapshot(this, false);
+                this.clear(false);
+                snapshot.getAliases().forEach(this::addAlias);
+                for (int id : snapshot.getIds().keySet()) {
+                    ResourceKey<T> idKey = ResourceKey.create(key, snapshot.getIds().get(id));
+                    registerIdMapping(idKey, id);
+                }
+                this.freeze();
             });
         }
     }

--- a/src/main/resources/Kilt.mixins.json
+++ b/src/main/resources/Kilt.mixins.json
@@ -86,6 +86,7 @@
         "workarounds.method_remap_workaround.MutableDataComponentHolderMixin",
         "workarounds.method_remap_workaround.ServerCommonPacketListenerImplMixin",
         "workarounds.method_remap_workaround.ServerConfigurationPacketListenerMixin",
+        "workarounds.registry_clear.MappedRegistryMixin",
         "world.inventory.GrindstoneMenuAccessor",
         "world.item.CreativeModeTabBuilderAccessor",
         "world.item.UseAnimAccessor",


### PR DESCRIPTION
Follow-up to https://github.com/KiltMC/NeoForge/pull/15 to make sure `onClear` is called for NeoForge and vanilla registries.