### PR TITLE
Make KeyBindsScreenInject more like the NeoForge 1.21.1 patch.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/injects/client/gui/screens/options/controls/KeyBindsScreenInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/client/gui/screens/options/controls/KeyBindsScreenInject.java
@@ -20,6 +20,7 @@ import net.minecraft.network.chat.Component;
 import net.neoforged.neoforge.client.extensions.IKeyMappingExtension;
 import net.neoforged.neoforge.client.settings.KeyModifier;
 import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -72,8 +73,7 @@ public abstract class KeyBindsScreenInject extends OptionsSubScreen {
     @Expression("keyCode == 256")
     @Inject(
         method = "keyPressed",
-        at = @At("MIXINEXTRAS:EXPRESSION"),
-        cancellable = true
+        at = @At("MIXINEXTRAS:EXPRESSION")
     )
     private void kilt$checkPassToRelease(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
         if (!kilt$releasing) {
@@ -86,7 +86,6 @@ public abstract class KeyBindsScreenInject extends OptionsSubScreen {
                 lastPressedKey = key;
                 isLastKeyHeldDown = true;
             }
-            cir.setReturnValue(true);
         }
     }
 
@@ -99,6 +98,7 @@ public abstract class KeyBindsScreenInject extends OptionsSubScreen {
         )
     )
     private void kilt$setKeyToUnbound(Options options, KeyMapping keyMapping, InputConstants.Key key, Operation<Void> original) {
+        if (!kilt$releasing) return;
         this.selectedKey.setKeyModifierAndCode(KeyModifier.NONE, InputConstants.UNKNOWN);
         original.call(options, keyMapping, key);
         lastPressedKey = InputConstants.UNKNOWN;
@@ -119,6 +119,7 @@ public abstract class KeyBindsScreenInject extends OptionsSubScreen {
         Options options, KeyMapping keyMapping, InputConstants.Key key, Operation<Void> original,
         @Cancellable CallbackInfoReturnable<Boolean> cir
     ) {
+        if (!kilt$releasing) return;
         if (lastPressedKey.equals(key)) {
             isLastKeyHeldDown = false;
         } else if (lastPressedModifier.equals(key)) {
@@ -140,6 +141,19 @@ public abstract class KeyBindsScreenInject extends OptionsSubScreen {
         } else {
             cir.setReturnValue(true);
         }
+    }
+
+    @Inject(
+        method = "keyPressed",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/client/gui/screens/options/controls/KeyBindsScreen;selectedKey:Lnet/minecraft/client/KeyMapping;",
+            opcode = Opcodes.PUTFIELD
+        ),
+        cancellable = true
+    )
+    private void kilt$afterSetKey(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+        if (!kilt$releasing) cir.setReturnValue(true);
     }
 
     @Intrinsic

--- a/src/main/java/xyz/bluspring/kilt/injects/client/gui/screens/options/controls/KeyBindsScreenInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/client/gui/screens/options/controls/KeyBindsScreenInject.java
@@ -128,9 +128,7 @@ public abstract class KeyBindsScreenInject extends OptionsSubScreen {
 
         if (!isLastKeyHeldDown && !isLastModifierHeldDown) {
             if (!lastPressedKey.equals(InputConstants.UNKNOWN)) {
-                this.selectedKey.setKeyModifierAndCode(
-                    KeyModifier.getKeyModifier(lastPressedModifier), lastPressedKey
-                );
+                this.selectedKey.setKeyModifierAndCode(KeyModifier.getKeyModifier(lastPressedModifier), lastPressedKey);
                 original.call(options, this.selectedKey, lastPressedKey);
             } else {
                 this.selectedKey.setKeyModifierAndCode(KeyModifier.NONE, lastPressedModifier);
@@ -167,7 +165,7 @@ public abstract class KeyBindsScreenInject extends OptionsSubScreen {
         if (kilt$doReleaseLogic.contains(key)) {
             kilt$doReleaseLogic.remove(key);
             kilt$releasing = true;
-            boolean result = keyPressed(keyCode, scanCode, modifiers);
+            boolean result = this.keyPressed(keyCode, scanCode, modifiers);
             kilt$releasing = false;
             return result;
         }

--- a/src/main/java/xyz/bluspring/kilt/injects/client/gui/screens/options/controls/KeyBindsScreenInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/client/gui/screens/options/controls/KeyBindsScreenInject.java
@@ -1,18 +1,20 @@
 // TRACKED HASH: df869ad68a72bbc774f9fc9ba2748e7540b906d7
 package xyz.bluspring.kilt.injects.client.gui.screens.options.controls;
 
-import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Cancellable;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.platform.InputConstants;
-import net.minecraft.Util;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
 import net.minecraft.client.gui.components.events.ContainerEventHandler;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.options.OptionsSubScreen;
-import net.minecraft.client.gui.screens.options.controls.KeyBindsList;
 import net.minecraft.client.gui.screens.options.controls.KeyBindsScreen;
 import net.minecraft.network.chat.Component;
 import net.neoforged.neoforge.client.extensions.IKeyMappingExtension;
@@ -23,12 +25,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @Mixin(KeyBindsScreen.class)
 @Implements(value = @Interface(iface = ContainerEventHandler.class, prefix = "kilt$i$"))
 public abstract class KeyBindsScreenInject extends OptionsSubScreen {
     @Shadow @Nullable public KeyMapping selectedKey;
-    @Shadow public long lastKeySelection;
-    @Shadow private KeyBindsList keyBindsList;
 
     @Unique private InputConstants.Key lastPressedKey = InputConstants.UNKNOWN;
     @Unique private InputConstants.Key lastPressedModifier = InputConstants.UNKNOWN;
@@ -45,21 +48,98 @@ public abstract class KeyBindsScreenInject extends OptionsSubScreen {
         ((IKeyMappingExtension) instance).setToDefault();
     }
 
-    // TODO: Neo doesn't do this anymore, but holy fuck their new patch is complicated
 
-    @Inject(method = "keyPressed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Options;setKey(Lnet/minecraft/client/KeyMapping;Lcom/mojang/blaze3d/platform/InputConstants$Key;)V", shift = At.Shift.BEFORE, ordinal = 0))
-    private void kilt$setKeyModifierUnknown(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
-        ((IKeyMappingExtension) this.selectedKey).setKeyModifierAndCode(KeyModifier.NONE, InputConstants.UNKNOWN);
+    @Unique
+    private boolean kilt$releasing = false;
+
+    @Unique
+    private final Set<InputConstants.Key> kilt$doReleaseLogic = new HashSet<>();
+
+    @Definition(id = "selectedKey", field = "Lnet/minecraft/client/gui/screens/options/controls/KeyBindsScreen;selectedKey:Lnet/minecraft/client/KeyMapping;")
+    @Expression("this.selectedKey != null")
+    @ModifyExpressionValue(
+        method = "keyPressed",
+        at = @At("MIXINEXTRAS:EXPRESSION")
+    )
+    private boolean kilt$checkOSX(boolean original, @Local(ordinal = 1, argsOnly = true) int scanCode) {
+        if (kilt$releasing) {
+            return original && (!Minecraft.ON_OSX || scanCode != 63);
+        }
+        return original;
     }
 
-    @Inject(method = "keyPressed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Options;setKey(Lnet/minecraft/client/KeyMapping;Lcom/mojang/blaze3d/platform/InputConstants$Key;)V", shift = At.Shift.BEFORE, ordinal = 1))
-    private void kilt$setKeyModifierToKey(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
-        ((IKeyMappingExtension) this.selectedKey).setKeyModifierAndCode(KeyModifier.NONE, InputConstants.getKey(keyCode, scanCode));
+    @Definition(id = "keyCode", local = @Local(type = int.class, argsOnly = true, ordinal = 0))
+    @Expression("keyCode == 256")
+    @Inject(
+        method = "keyPressed",
+        at = @At("MIXINEXTRAS:EXPRESSION"),
+        cancellable = true
+    )
+    private void kilt$checkPassToRelease(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+        if (!kilt$releasing) {
+            var key = InputConstants.getKey(keyCode, scanCode);
+            kilt$doReleaseLogic.add(key);
+            if (lastPressedModifier == InputConstants.UNKNOWN && KeyModifier.isKeyCodeModifier(key)) {
+                lastPressedModifier = key;
+                isLastModifierHeldDown = true;
+            } else {
+                lastPressedKey = key;
+                isLastKeyHeldDown = true;
+            }
+            cir.setReturnValue(true);
+        }
     }
 
-    @WrapWithCondition(method = "keyPressed", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/screens/options/controls/KeyBindsScreen;selectedKey:Lnet/minecraft/client/KeyMapping;", ordinal = 3))
-    private boolean kilt$setSelectedKeyNullWhenNotModifier(KeyBindsScreen instance, KeyMapping value, @Local(argsOnly = true, ordinal = 0) int keyCode) {
-        return keyCode == 256 || !KeyModifier.isKeyCodeModifier(((IKeyMappingExtension) this.selectedKey).getKey());
+    @WrapOperation(
+        method = "keyPressed",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/Options;setKey(Lnet/minecraft/client/KeyMapping;Lcom/mojang/blaze3d/platform/InputConstants$Key;)V",
+            ordinal = 0
+        )
+    )
+    private void kilt$setKeyToUnbound(Options options, KeyMapping keyMapping, InputConstants.Key key, Operation<Void> original) {
+        this.selectedKey.setKeyModifierAndCode(KeyModifier.NONE, InputConstants.UNKNOWN);
+        original.call(options, keyMapping, key);
+        lastPressedKey = InputConstants.UNKNOWN;
+        lastPressedModifier = InputConstants.UNKNOWN;
+        isLastKeyHeldDown = false;
+        isLastModifierHeldDown = false;
+    }
+
+    @WrapOperation(
+        method = "keyPressed",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/Options;setKey(Lnet/minecraft/client/KeyMapping;Lcom/mojang/blaze3d/platform/InputConstants$Key;)V",
+            ordinal = 1
+        )
+    )
+    private void kilt$setKey(
+        Options options, KeyMapping keyMapping, InputConstants.Key key, Operation<Void> original,
+        @Cancellable CallbackInfoReturnable<Boolean> cir
+    ) {
+        if (lastPressedKey.equals(key)) {
+            isLastKeyHeldDown = false;
+        } else if (lastPressedModifier.equals(key)) {
+            isLastModifierHeldDown = false;
+        }
+
+        if (!isLastKeyHeldDown && !isLastModifierHeldDown) {
+            if (!lastPressedKey.equals(InputConstants.UNKNOWN)) {
+                this.selectedKey.setKeyModifierAndCode(
+                    KeyModifier.getKeyModifier(lastPressedModifier), lastPressedKey
+                );
+                original.call(options, this.selectedKey, lastPressedKey);
+            } else {
+                this.selectedKey.setKeyModifierAndCode(KeyModifier.NONE, lastPressedModifier);
+                original.call(options, this.selectedKey, lastPressedModifier);
+            }
+            lastPressedKey = InputConstants.UNKNOWN;
+            lastPressedModifier = InputConstants.UNKNOWN;
+        } else {
+            cir.setReturnValue(true);
+        }
     }
 
     @Intrinsic
@@ -69,15 +149,14 @@ public abstract class KeyBindsScreenInject extends OptionsSubScreen {
 
     @Intrinsic(displace = true) // Kilt: this still feels like magic to me but oh well
     public boolean kilt$i$keyReleased(int keyCode, int scanCode, int modifiers) {
-        // Forge: We wait for a second key above if the first press is a modifier
-        // but if they release the modifier then set it explicitly.
         var key = InputConstants.getKey(keyCode, scanCode);
-        if (this.selectedKey != null && this.selectedKey.getKey() == key) {
-            this.selectedKey = null;
-            this.lastKeySelection = Util.getMillis();
-            this.keyBindsList.resetMappingAndUpdateButtons();
+        if (kilt$doReleaseLogic.contains(key)) {
+            kilt$doReleaseLogic.remove(key);
+            kilt$releasing = true;
+            boolean result = keyPressed(keyCode, scanCode, modifiers);
+            kilt$releasing = false;
+            return result;
         }
-
         return this.keyReleased(keyCode, scanCode, modifiers);
     }
 }


### PR DESCRIPTION
Basically, I just cancel `keyPressed` early and run the rest of `keyPressed` from `keyReleased`.
I decided to still step past the `setKey` functions before cancelling when not in the release phase to allow mods like Amecs to handle keybinds on its own.

This PR alone won't fix Amecs, but I'm thinking of reworking the Amecs compatibility to essentially let Amecs handle key modifiers instead. My reasoning is that Amecs has support for multiple key modifiers at once, while NeoForge/Kilt only supports one at a time.