### PR TITLE
Created ModifiedCloneWorkaroundLoader to handle signature-changing patches.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/injects/world/entity/ai/goal/RangedBowAttackGoalInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/world/entity/ai/goal/RangedBowAttackGoalInject.java
@@ -5,7 +5,6 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.goal.RangedBowAttackGoal;
 import net.minecraft.world.entity.monster.Monster;
@@ -16,20 +15,11 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import xyz.bluspring.kilt.helpers.mixin.CreateInitializer;
 import xyz.bluspring.kilt.injections.world.entity.projectile.ProjectileUtilInjection;
 
 @Mixin(RangedBowAttackGoal.class)
 public abstract class RangedBowAttackGoalInject<T extends Monster & RangedAttackMob> extends Goal {
-    // Kilt: ----We don't need to implement the custom constructor stuff----
-    //       (he said, like a fucking liar)
-
-    @CreateInitializer
-    public <M extends Mob & RangedAttackMob> RangedBowAttackGoalInject(M mob, double speedModifier, int attackIntervalMin, float attackRadius) {
-        this((T) mob, speedModifier, attackIntervalMin, attackRadius);
-    }
-
-    public RangedBowAttackGoalInject(T mob, double speedModifier, int attackIntervalMin, float attackRadius) {}
+    // Kilt: We don't need to implement the custom constructor stuff
 
     @Shadow @Final private T mob;
 

--- a/src/main/java/xyz/bluspring/kilt/injects/world/entity/ai/goal/RangedBowAttackGoalInject.java
+++ b/src/main/java/xyz/bluspring/kilt/injects/world/entity/ai/goal/RangedBowAttackGoalInject.java
@@ -3,13 +3,6 @@ package xyz.bluspring.kilt.injects.world.entity.ai.goal;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.gen.Accessor;
-import org.spongepowered.asm.mixin.injection.At;
-import xyz.bluspring.kilt.helpers.mixin.CreateInitializer;
-import xyz.bluspring.kilt.injections.world.entity.projectile.ProjectileUtilInjection;
-
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
@@ -19,6 +12,12 @@ import net.minecraft.world.entity.monster.Monster;
 import net.minecraft.world.entity.monster.RangedAttackMob;
 import net.minecraft.world.item.BowItem;
 import net.minecraft.world.item.Item;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import xyz.bluspring.kilt.helpers.mixin.CreateInitializer;
+import xyz.bluspring.kilt.injections.world.entity.projectile.ProjectileUtilInjection;
 
 @Mixin(RangedBowAttackGoal.class)
 public abstract class RangedBowAttackGoalInject<T extends Monster & RangedAttackMob> extends Goal {
@@ -27,19 +26,16 @@ public abstract class RangedBowAttackGoalInject<T extends Monster & RangedAttack
 
     @CreateInitializer
     public <M extends Mob & RangedAttackMob> RangedBowAttackGoalInject(M mob, double speedModifier, int attackIntervalMin, float attackRadius) {
-        this(mob instanceof Monster ? (T) mob : null, speedModifier, attackIntervalMin, attackRadius);
-        this.mob = mob;
+        this((T) mob, speedModifier, attackIntervalMin, attackRadius);
     }
 
     public RangedBowAttackGoalInject(T mob, double speedModifier, int attackIntervalMin, float attackRadius) {}
 
-    // Kilt: this is stupid
-    @Accessor("mob") public abstract T kilt$i$getMob();
-    private Mob mob;
+    @Shadow @Final private T mob;
 
     @ModifyReturnValue(method = "isHoldingBow", at = @At("RETURN"))
     private boolean kilt$tryCheckHoldingItem(boolean original) {
-        return original || this.kilt$tryUsingMob(this.kilt$i$getMob()).isHolding(is -> is.getItem() instanceof BowItem);
+        return original || this.mob.isHolding(is -> is.getItem() instanceof BowItem);
     }
 
     @WrapOperation(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/ProjectileUtil;getWeaponHoldingHand(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/Item;)Lnet/minecraft/world/InteractionHand;"))
@@ -49,14 +45,5 @@ public abstract class RangedBowAttackGoalInject<T extends Monster & RangedAttack
         }
 
         return ProjectileUtilInjection.getWeaponHoldingHand(shooter, item -> item instanceof BowItem);
-    }
-
-    @Unique
-    private Mob kilt$tryUsingMob(T original) {
-        if (original != null) {
-            return original;
-        } else {
-            return this.mob;
-        }
     }
 }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -54,6 +54,7 @@ import xyz.bluspring.kilt.loader.provider.NoopLanguageLoader
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import xyz.bluspring.kilt.util.DistUtil
 import xyz.bluspring.kilt.util.KiltHelper
+import xyz.bluspring.kilt.util.ModifiedCloneWorkaroundLoader
 import xyz.bluspring.kilt.util.buildGraph
 import xyz.bluspring.knit.loader.KnitLoader
 import xyz.bluspring.knit.loader.KnitModLoader
@@ -635,6 +636,7 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
         // Load Java coremods, this should be handled before access transformers so we don't mess with access modifier stuff.
         // Although, people probably shouldn't be relying on that.
         CoreModLoader.loadJavaCoreMods()
+        ModifiedCloneWorkaroundLoader.init() // Init this after coremods so the post transforms always run after.
 
         // Load all of the Forge access transformers
         AccessTransformerLoader.runTransformers()

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -636,7 +636,7 @@ class KiltLoader : KnitModLoader<NeoForgeMod>(Kilt.MOD_ID, "NeoForge") {
         // Load Java coremods, this should be handled before access transformers so we don't mess with access modifier stuff.
         // Although, people probably shouldn't be relying on that.
         CoreModLoader.loadJavaCoreMods()
-        ModifiedCloneWorkaroundLoader.init() // Init this after coremods so the post transforms always run after.
+        ModifiedCloneWorkaroundLoader.load() // Init this after coremods so the post transforms always run after.
 
         // Load all of the Forge access transformers
         AccessTransformerLoader.runTransformers()

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -54,7 +54,7 @@ import xyz.bluspring.kilt.loader.provider.NoopLanguageLoader
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import xyz.bluspring.kilt.util.DistUtil
 import xyz.bluspring.kilt.util.KiltHelper
-import xyz.bluspring.kilt.util.ModifiedCloneWorkaroundLoader
+import xyz.bluspring.kilt.workarounds.ModifiedCloneWorkaroundLoader
 import xyz.bluspring.kilt.util.buildGraph
 import xyz.bluspring.knit.loader.KnitLoader
 import xyz.bluspring.knit.loader.KnitModLoader

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltEarlyRiser.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltEarlyRiser.kt
@@ -390,43 +390,6 @@ class KiltEarlyRiser : Runnable {
             }
         }
 
-        // Neo changes the signature here, which.. changes the whole fucking class.
-        // Mass ASM time in probably the dumbest way possible.
-        /*run {
-            val goalMapped = KiltRemapper.remapClass("net/minecraft/world/entity/ai/goal/RangedBowAttackGoal")
-            val mobClassMapped = KiltRemapper.remapClass("net/minecraft/world/entity/Mob")
-            val monsterClassMapped = KiltRemapper.remapClass("net/minecraft/world/entity/monster/Monster")
-            val mobMapped = FabricLoader.getInstance().mappingResolver.mapFieldName("intermediary", "net.minecraft.class_1380", "mob", "Lnet/minecraft/world/entity/monster/Monster;")
-            ClassTinkerers.addPostTransformation(goalMapped) { classNode ->
-                for (methodNode in classNode.methods) {
-                    if (methodNode.name == $$"kilt$tryUsingMob" || methodNode.name.startsWith($$"kilt$i$") || Modifier.isStatic(methodNode.access))
-                        continue
-
-                    val afterInsns = mutableMapOf<AbstractInsnNode, InsnList>()
-                    for (insnNode in methodNode.instructions) {
-                        if (insnNode is FieldInsnNode && insnNode.opcode == Opcodes.GETFIELD && insnNode.owner == goalMapped && insnNode.name == mobMapped && insnNode.desc == "L${monsterClassMapped};") {
-                            val list = InsnList()
-                            list.add(VarInsnNode(Opcodes.ALOAD, 0))
-                            list.add(FieldInsnNode(insnNode.opcode, insnNode.owner, insnNode.name, insnNode.desc))
-                            list.add(MethodInsnNode(Opcodes.INVOKEVIRTUAL, insnNode.owner, $$"kilt$tryUsingMob", "(L$monsterClassMapped;)L$mobClassMapped;", false))
-                            afterInsns[insnNode] = list
-                        }
-                    }
-
-                    val beforeNodes = mutableMapOf<AbstractInsnNode, AbstractInsnNode>()
-                    for (before in afterInsns.keys) {
-                        beforeNodes[before] = before.previous
-                    }
-
-                    for ((before, after) in afterInsns) {
-                        val prevNode = beforeNodes[before]!!
-                        methodNode.instructions.remove(before)
-                        methodNode.instructions.insert(prevNode, after)
-                    }
-                }
-            }
-        }*/
-
         // Turns out some mods extend some final classes in Sodium, which are apparently not final in Rubidium/Embeddium.
         if (FabricLoader.getInstance().isModLoaded("sodium")) {
             ClassTinkerers.addTransformation("me.jellysquid.mods.sodium.client.world.WorldSlice") { classNode ->

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
@@ -41,7 +41,7 @@ import xyz.bluspring.kilt.loader.remap.resource.ManifestResourceRemapper
 import xyz.bluspring.kilt.util.CaseInsensitiveStringHashSet
 import xyz.bluspring.kilt.util.ClassNameHashSet
 import xyz.bluspring.kilt.util.KiltHelper
-import xyz.bluspring.kilt.util.ModifiedCloneWorkaroundLoader
+import xyz.bluspring.kilt.workarounds.ModifiedCloneWorkaroundLoader
 import xyz.bluspring.knit.loader.mod.ModDefinition
 import xyz.bluspring.knit.loader.util.collect
 import xyz.bluspring.knit.loader.util.concurrent

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
@@ -41,6 +41,7 @@ import xyz.bluspring.kilt.loader.remap.resource.ManifestResourceRemapper
 import xyz.bluspring.kilt.util.CaseInsensitiveStringHashSet
 import xyz.bluspring.kilt.util.ClassNameHashSet
 import xyz.bluspring.kilt.util.KiltHelper
+import xyz.bluspring.kilt.util.ModifiedCloneWorkaroundLoader
 import xyz.bluspring.knit.loader.mod.ModDefinition
 import xyz.bluspring.knit.loader.util.collect
 import xyz.bluspring.knit.loader.util.concurrent
@@ -526,6 +527,7 @@ object KiltRemapper {
                             EnvironmentRemapper.remapClass(remappedNode)
                             EnvironmentLambdaFixer.fixClass(remappedNode)
                             RemoveModulesFixer.fixClass(remappedNode)
+                            ModifiedCloneWorkaroundLoader.fixClass(remappedNode)
                         }
 
                         val writer = ClassWriter(Opcodes.ASM9)

--- a/src/main/kotlin/xyz/bluspring/kilt/util/ModifiedCloneWorkaroundLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/ModifiedCloneWorkaroundLoader.kt
@@ -1,0 +1,305 @@
+package xyz.bluspring.kilt.util
+
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Handle
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.*
+import xyz.bluspring.fork.mm.api.ClassTinkerers
+import xyz.bluspring.kilt.loader.remap.KiltRemapper
+
+object ModifiedCloneWorkaroundLoader {
+
+    fun init() {
+        val monsterType = KiltRemapper.remapClass("net/minecraft/world/entity/monster/Monster")
+        val monsterDesc = "L$monsterType;"
+        val mobType = KiltRemapper.remapClass("net/minecraft/world/entity/Mob")
+        val mobDesc = "L$mobType;"
+        val rangedAttackMob = KiltRemapper.remapDescriptor("Lnet/minecraft/world/entity/monster/RangedAttackMob;")
+        run {
+            val bowAttackGoal = "net/minecraft/world/entity/ai/goal/RangedBowAttackGoal"
+            val bowAttackGoalClone = "xyz/bluspring/kilt/workarounds/RangedBowAttackGoalWorkaround"
+            addTransformedClone(
+                KiltRemapper.remapClass(bowAttackGoal),
+                bowAttackGoalClone,
+            ) { classNode ->
+                replaceType(classNode, monsterType, mobType)
+
+                val fallbackConstructor = MethodNode(
+                    Opcodes.ACC_PUBLIC, "<init>", "(${monsterDesc}DIF)V",
+                    "<M:$monsterDesc:$rangedAttackMob>(TM;DIF)V", null
+                ).apply {
+                    val startLabel = LabelNode()
+                    this.instructions.add(startLabel)
+                    this.instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+                    this.instructions.add(VarInsnNode(Opcodes.ALOAD, 1))
+                    this.instructions.add(VarInsnNode(Opcodes.DLOAD, 2)) // Fun fact, double parameters take 2 variable slots.
+                    this.instructions.add(VarInsnNode(Opcodes.ILOAD, 4))
+                    this.instructions.add(VarInsnNode(Opcodes.FLOAD, 5))
+                    this.instructions.add(
+                        MethodInsnNode(
+                            Opcodes.INVOKESPECIAL, bowAttackGoalClone,
+                            "<init>", "(${mobDesc}DIF)V"
+                        )
+                    )
+                    this.instructions.add(LabelNode())
+                    this.instructions.add(InsnNode(Opcodes.RETURN))
+                    val endLabel = LabelNode()
+                    this.instructions.add(endLabel)
+
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "this", "L$bowAttackGoalClone;", "L$bowAttackGoalClone<TT;>;",
+                            startLabel, endLabel, 0
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "mob", monsterDesc, "TM;",
+                            startLabel, endLabel, 1
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "speedModifier", "D", null,
+                            startLabel, endLabel, 2
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "attackIntervalMin", "I", null,
+                            startLabel, endLabel, 4
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "attackRadius", "F", null,
+                            startLabel, endLabel, 5
+                        )
+                    )
+                }
+                classNode.methods.add(fallbackConstructor)
+            }
+        }
+
+        run {
+            val crossbowAttackGoal = "net/minecraft/world/entity/ai/goal/RangedCrossbowAttackGoal"
+            val crossbowAttackGoalClone = "xyz/bluspring/kilt/workarounds/RangedCrossbowAttackGoalWorkaround"
+            addTransformedClone(
+                KiltRemapper.remapClass(crossbowAttackGoal),
+                crossbowAttackGoalClone,
+            ) { classNode ->
+                replaceType(classNode, monsterType, mobType)
+
+                val fallbackConstructor = MethodNode(
+                    Opcodes.ACC_PUBLIC, "<init>", "(${monsterDesc}DF)V",
+                    "<M:$monsterDesc:$rangedAttackMob:${KiltRemapper.remapDescriptor("Lnet/minecraft/world/entity/monster/CrossbowAttackMob;")}>(TM;DF)V", null
+                ).apply {
+                    val startLabel = LabelNode()
+                    this.instructions.add(startLabel)
+                    this.instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+                    this.instructions.add(VarInsnNode(Opcodes.ALOAD, 1))
+                    this.instructions.add(VarInsnNode(Opcodes.DLOAD, 2)) // Fun fact, double parameters take 2 variable slots.
+                    this.instructions.add(VarInsnNode(Opcodes.FLOAD, 4))
+                    this.instructions.add(
+                        MethodInsnNode(
+                            Opcodes.INVOKESPECIAL, crossbowAttackGoalClone,
+                            "<init>", "(${mobDesc}DF)V"
+                        )
+                    )
+                    this.instructions.add(LabelNode())
+                    this.instructions.add(InsnNode(Opcodes.RETURN))
+                    val endLabel = LabelNode()
+                    this.instructions.add(endLabel)
+
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "this", "L$crossbowAttackGoalClone;", "L$crossbowAttackGoalClone<TT;>;",
+                            startLabel, endLabel, 0
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "mob", monsterDesc, "TM;",
+                            startLabel, endLabel, 1
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "speedModifier", "D", null,
+                            startLabel, endLabel, 2
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "attackRadius", "F", null,
+                            startLabel, endLabel, 4
+                        )
+                    )
+                }
+                classNode.methods.add(fallbackConstructor)
+            }
+        }
+    }
+
+    private fun mapType(type: Type, oldTypeName: String, newTypeDesc: String): Type {
+        when (type.sort) {
+            Type.OBJECT -> {
+                if (type.internalName == oldTypeName) {
+                    return Type.getType(newTypeDesc)
+                }
+            }
+            Type.ARRAY -> {
+                val dimensions = type.dimensions
+                val elementType = type.elementType
+                if (elementType.internalName == oldTypeName) {
+                    return Type.getType("[".repeat(dimensions) + newTypeDesc)
+                }
+            }
+        }
+        return type
+    }
+
+    private fun mapHandle(handle: Handle, oldTypeName: String, newTypeName: String): Handle {
+        if (handle.owner == oldTypeName) {
+            return Handle(
+                handle.tag, newTypeName, handle.name, handle.desc, handle.isInterface
+            )
+        }
+        return handle
+    }
+
+    private fun mapFrameTypes(frameTypes: List<Any?>?, oldOwnerName: String, newOwnerName: String): List<Any?>? {
+        if (frameTypes == null) return frameTypes
+        var newTypes: MutableList<Any?>? = null
+        for (i in frameTypes.indices) {
+            val type = frameTypes[i]
+            if (type is String && type == oldOwnerName) {
+                if (newTypes == null) {
+                    newTypes = frameTypes.toMutableList()
+                }
+                newTypes[i] = newOwnerName
+            }
+        }
+        return newTypes ?: frameTypes
+    }
+
+    private fun setClassName(node: ClassNode, oldOwnerName: String, newOwnerName: String) {
+        val oldOwnerDesc = "L$oldOwnerName;"
+        val newOwnerDesc = "L$newOwnerName;"
+        node.name = newOwnerName
+        for (method in node.methods) {
+            for (insn in method.instructions) {
+                when (insn) {
+                    is FieldInsnNode -> if (insn.owner == oldOwnerName) insn.owner = newOwnerName
+                    is MethodInsnNode -> if (insn.owner == oldOwnerName) insn.owner = newOwnerName
+                    is LdcInsnNode -> {
+                        val type = insn.cst
+                        if (type is Type) {
+                            insn.cst = mapType(type, oldOwnerName, newOwnerDesc)
+                        }
+                    }
+                    is TypeInsnNode -> if (insn.desc == oldOwnerName) insn.desc = newOwnerName
+                    is InvokeDynamicInsnNode -> {
+                        for (i in insn.bsmArgs.indices) {
+                            val arg = insn.bsmArgs[i]
+                            when (arg) {
+                                is Type -> insn.bsmArgs[i] = mapType(arg, oldOwnerName, newOwnerDesc)
+                                is Handle -> insn.bsmArgs[i] = mapHandle(arg, oldOwnerName, newOwnerName)
+                            }
+                        }
+                    }
+                    is FrameNode -> {
+                        insn.local = mapFrameTypes(insn.local, oldOwnerName, newOwnerName)
+                        insn.stack = mapFrameTypes(insn.stack, oldOwnerName, newOwnerName)
+                    }
+                }
+            }
+            for (local in method.localVariables) {
+                if (local.desc == oldOwnerDesc) {
+                    local.desc = newOwnerDesc
+                }
+                local.signature = local.signature?.replace(oldOwnerName, newOwnerName)
+            }
+            method.signature = method.signature?.replace(oldOwnerName, newOwnerName)
+        }
+        for (field in node.fields) {
+            field.signature = field.signature?.replace(oldOwnerName, newOwnerName)
+        }
+    }
+
+    fun addTransformedClone(
+        targetClass: String, cloneClass: String,
+        transformer: (ClassNode) -> Unit
+    ) {
+        var originalNode: ClassNode? = null
+        ClassTinkerers.addPostTransformation(targetClass) { classNode ->
+            originalNode = classNode
+        }
+        val cw = ClassWriter(0)
+        cw.visit(
+            52,
+            Opcodes.ACC_PUBLIC,
+            cloneClass,
+            null,
+            "java/lang/Object",
+            null
+        )
+        ClassTinkerers.define(cloneClass, cw.toByteArray())
+        ClassTinkerers.addPostTransformation(cloneClass) { classNode ->
+            Class.forName(targetClass.replace("/", ".")) // Classload it somehow so the transform always runs first
+            originalNode?.accept(classNode)
+
+            setClassName(classNode, targetClass, cloneClass)
+
+            transformer(classNode)
+        }
+    }
+
+    fun replaceType(
+        classNode: ClassNode,
+        oldType: String,
+        newType: String
+    ) {
+        val oldDescriptor = "L$oldType;"
+        val newDescriptor = "L$newType;"
+        classNode.signature = classNode.signature?.replace(oldDescriptor, newDescriptor)
+
+        for (field in classNode.fields) {
+            if (field.desc == oldDescriptor) {
+                field.desc = newDescriptor
+            }
+            field.signature = field.signature?.replace(oldDescriptor, newDescriptor)
+        }
+
+        for (method in classNode.methods) {
+            method.desc = method.desc.replace(oldDescriptor, newDescriptor)
+            method.signature = method.signature?.replace(oldDescriptor, newDescriptor)
+        }
+
+        for (method in classNode.methods) {
+            for (insn in method.instructions) {
+                when (insn) {
+                    is FieldInsnNode -> {
+                        if (insn.owner == oldType) {
+                            insn.owner = newType
+                        }
+                        insn.desc = insn.desc.replace(oldDescriptor, newDescriptor)
+                    }
+                    is MethodInsnNode -> {
+                        if (insn.owner == oldType) {
+                            insn.owner = newType
+                        }
+                        insn.desc = insn.desc.replace(oldDescriptor, newDescriptor)
+                    }
+                }
+            }
+            for (local in method.localVariables) {
+                if (local.desc == oldDescriptor) {
+                    local.desc = newDescriptor
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/xyz/bluspring/kilt/util/ModifiedCloneWorkaroundLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/ModifiedCloneWorkaroundLoader.kt
@@ -10,7 +10,10 @@ import xyz.bluspring.kilt.loader.remap.KiltRemapper
 
 object ModifiedCloneWorkaroundLoader {
 
-    fun init() {
+    val REMAPPED_TYPES = mutableMapOf<String, String>()
+    val TRANSFORMERS = mutableListOf<() -> Unit>()
+
+    init {
         val monsterType = KiltRemapper.remapClass("net/minecraft/world/entity/monster/Monster")
         val monsterDesc = "L$monsterType;"
         val mobType = KiltRemapper.remapClass("net/minecraft/world/entity/Mob")
@@ -142,6 +145,11 @@ object ModifiedCloneWorkaroundLoader {
         }
     }
 
+    fun load() {
+        TRANSFORMERS.forEach { it() }
+        TRANSFORMERS.clear()
+    }
+
     private fun mapType(type: Type, oldTypeName: String, newTypeDesc: String): Type {
         when (type.sort) {
             Type.OBJECT -> {
@@ -185,74 +193,38 @@ object ModifiedCloneWorkaroundLoader {
     }
 
     private fun setClassName(node: ClassNode, oldOwnerName: String, newOwnerName: String) {
-        val oldOwnerDesc = "L$oldOwnerName;"
-        val newOwnerDesc = "L$newOwnerName;"
         node.name = newOwnerName
-        for (method in node.methods) {
-            for (insn in method.instructions) {
-                when (insn) {
-                    is FieldInsnNode -> if (insn.owner == oldOwnerName) insn.owner = newOwnerName
-                    is MethodInsnNode -> if (insn.owner == oldOwnerName) insn.owner = newOwnerName
-                    is LdcInsnNode -> {
-                        val type = insn.cst
-                        if (type is Type) {
-                            insn.cst = mapType(type, oldOwnerName, newOwnerDesc)
-                        }
-                    }
-                    is TypeInsnNode -> if (insn.desc == oldOwnerName) insn.desc = newOwnerName
-                    is InvokeDynamicInsnNode -> {
-                        for (i in insn.bsmArgs.indices) {
-                            val arg = insn.bsmArgs[i]
-                            when (arg) {
-                                is Type -> insn.bsmArgs[i] = mapType(arg, oldOwnerName, newOwnerDesc)
-                                is Handle -> insn.bsmArgs[i] = mapHandle(arg, oldOwnerName, newOwnerName)
-                            }
-                        }
-                    }
-                    is FrameNode -> {
-                        insn.local = mapFrameTypes(insn.local, oldOwnerName, newOwnerName)
-                        insn.stack = mapFrameTypes(insn.stack, oldOwnerName, newOwnerName)
-                    }
-                }
-            }
-            for (local in method.localVariables) {
-                if (local.desc == oldOwnerDesc) {
-                    local.desc = newOwnerDesc
-                }
-                local.signature = local.signature?.replace(oldOwnerName, newOwnerName)
-            }
-            method.signature = method.signature?.replace(oldOwnerName, newOwnerName)
-        }
-        for (field in node.fields) {
-            field.signature = field.signature?.replace(oldOwnerName, newOwnerName)
-        }
+        replaceType(node, oldOwnerName, newOwnerName)
     }
 
     fun addTransformedClone(
         targetClass: String, cloneClass: String,
         transformer: (ClassNode) -> Unit
     ) {
-        var originalNode: ClassNode? = null
-        ClassTinkerers.addPostTransformation(targetClass) { classNode ->
-            originalNode = classNode
-        }
-        val cw = ClassWriter(0)
-        cw.visit(
-            52,
-            Opcodes.ACC_PUBLIC,
-            cloneClass,
-            null,
-            "java/lang/Object",
-            null
-        )
-        ClassTinkerers.define(cloneClass, cw.toByteArray())
-        ClassTinkerers.addPostTransformation(cloneClass) { classNode ->
-            Class.forName(targetClass.replace("/", ".")) // Classload it somehow so the transform always runs first
-            originalNode?.accept(classNode)
+        REMAPPED_TYPES[targetClass] = cloneClass
+        TRANSFORMERS.add {
+            var originalNode: ClassNode? = null
+            ClassTinkerers.addPostTransformation(targetClass) { classNode ->
+                originalNode = classNode
+            }
+            val cw = ClassWriter(0)
+            cw.visit(
+                52,
+                Opcodes.ACC_PUBLIC,
+                cloneClass,
+                null,
+                "java/lang/Object",
+                null
+            )
+            ClassTinkerers.define(cloneClass, cw.toByteArray())
+            ClassTinkerers.addPostTransformation(cloneClass) { classNode ->
+                Class.forName(targetClass.replace("/", ".")) // Classload it somehow so the transform always runs first
+                originalNode?.accept(classNode)
 
-            setClassName(classNode, targetClass, cloneClass)
+                setClassName(classNode, targetClass, cloneClass)
 
-            transformer(classNode)
+                transformer(classNode)
+            }
         }
     }
 
@@ -264,6 +236,16 @@ object ModifiedCloneWorkaroundLoader {
         val oldDescriptor = "L$oldType;"
         val newDescriptor = "L$newType;"
         classNode.signature = classNode.signature?.replace(oldDescriptor, newDescriptor)
+        if (classNode.superName == oldType) {
+            classNode.superName = newType
+        }
+
+        classNode.interfaces = classNode.interfaces.map {
+            if (it == oldType) {
+                return@map newType
+            }
+            return@map it
+        }
 
         for (field in classNode.fields) {
             if (field.desc == oldDescriptor) {
@@ -292,14 +274,44 @@ object ModifiedCloneWorkaroundLoader {
                         }
                         insn.desc = insn.desc.replace(oldDescriptor, newDescriptor)
                     }
+                    is LdcInsnNode -> {
+                        val type = insn.cst
+                        if (type is Type) {
+                            insn.cst = mapType(type, oldType, newDescriptor)
+                        }
+                    }
+                    is TypeInsnNode -> if (insn.desc == oldType) insn.desc = newType
+                    is InvokeDynamicInsnNode -> {
+                        for (i in insn.bsmArgs.indices) {
+                            val arg = insn.bsmArgs[i]
+                            when (arg) {
+                                is Type -> insn.bsmArgs[i] = mapType(arg, oldType, newDescriptor)
+                                is Handle -> insn.bsmArgs[i] = mapHandle(arg, oldType, newType)
+                            }
+                        }
+                    }
+                    is FrameNode -> {
+                        insn.local = mapFrameTypes(insn.local, oldType, newDescriptor)
+                        insn.stack = mapFrameTypes(insn.stack, oldType, newDescriptor)
+                    }
                 }
             }
-            for (local in method.localVariables) {
-                if (local.desc == oldDescriptor) {
-                    local.desc = newDescriptor
+            if (method.localVariables != null) {
+                for (local in method.localVariables) {
+                    if (local.desc == oldDescriptor) {
+                        local.desc = newDescriptor
+                    }
+                    local.signature = local.signature?.replace(oldType, newType)
                 }
             }
+            method.signature = method.signature?.replace(oldType, newType)
         }
+
     }
 
+    fun fixClass(classNode: ClassNode) {
+        for ((from, to) in REMAPPED_TYPES) {
+            replaceType(classNode, from, to)
+        }
+    }
 }

--- a/src/main/kotlin/xyz/bluspring/kilt/workarounds/ModifiedCloneWorkaroundLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/workarounds/ModifiedCloneWorkaroundLoader.kt
@@ -1,17 +1,29 @@
-package xyz.bluspring.kilt.util
+package xyz.bluspring.kilt.workarounds
 
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Handle
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
-import org.objectweb.asm.tree.*
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.FieldInsnNode
+import org.objectweb.asm.tree.FrameNode
+import org.objectweb.asm.tree.InsnNode
+import org.objectweb.asm.tree.InvokeDynamicInsnNode
+import org.objectweb.asm.tree.LabelNode
+import org.objectweb.asm.tree.LdcInsnNode
+import org.objectweb.asm.tree.LocalVariableNode
+import org.objectweb.asm.tree.MethodInsnNode
+import org.objectweb.asm.tree.MethodNode
+import org.objectweb.asm.tree.TypeInsnNode
+import org.objectweb.asm.tree.VarInsnNode
 import xyz.bluspring.fork.mm.api.ClassTinkerers
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
+import kotlin.collections.iterator
 
 object ModifiedCloneWorkaroundLoader {
 
     val REMAPPED_TYPES = mutableMapOf<String, String>()
-    val TRANSFORMERS = mutableListOf<() -> Unit>()
+    val TRANSFORMERS = mutableListOf<Runnable>()
 
     init {
         val monsterType = KiltRemapper.remapClass("net/minecraft/world/entity/monster/Monster")
@@ -29,9 +41,9 @@ object ModifiedCloneWorkaroundLoader {
                 replaceType(classNode, monsterType, mobType)
 
                 val fallbackConstructor = MethodNode(
-                    Opcodes.ACC_PUBLIC, "<init>", "(${monsterDesc}DIF)V",
-                    "<M:$monsterDesc:$rangedAttackMob>(TM;DIF)V", null
-                ).apply {
+					Opcodes.ACC_PUBLIC, "<init>", "(${monsterDesc}DIF)V",
+					"<M:$monsterDesc:$rangedAttackMob>(TM;DIF)V", null
+				).apply {
                     val startLabel = LabelNode()
                     this.instructions.add(startLabel)
                     this.instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
@@ -39,47 +51,20 @@ object ModifiedCloneWorkaroundLoader {
                     this.instructions.add(VarInsnNode(Opcodes.DLOAD, 2)) // Fun fact, double parameters take 2 variable slots.
                     this.instructions.add(VarInsnNode(Opcodes.ILOAD, 4))
                     this.instructions.add(VarInsnNode(Opcodes.FLOAD, 5))
-                    this.instructions.add(
-                        MethodInsnNode(
-                            Opcodes.INVOKESPECIAL, bowAttackGoalClone,
-                            "<init>", "(${mobDesc}DIF)V"
-                        )
-                    )
+                    this.instructions.add(MethodInsnNode(
+                        Opcodes.INVOKESPECIAL, bowAttackGoalClone,
+                        "<init>", "(${mobDesc}DIF)V"
+                    ))
                     this.instructions.add(LabelNode())
                     this.instructions.add(InsnNode(Opcodes.RETURN))
                     val endLabel = LabelNode()
                     this.instructions.add(endLabel)
 
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "this", "L$bowAttackGoalClone;", "L$bowAttackGoalClone<TT;>;",
-                            startLabel, endLabel, 0
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "mob", monsterDesc, "TM;",
-                            startLabel, endLabel, 1
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "speedModifier", "D", null,
-                            startLabel, endLabel, 2
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "attackIntervalMin", "I", null,
-                            startLabel, endLabel, 4
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "attackRadius", "F", null,
-                            startLabel, endLabel, 5
-                        )
-                    )
+                    this.localVariables.add(LocalVariableNode("this", "L$bowAttackGoalClone;", "L$bowAttackGoalClone<TT;>;", startLabel, endLabel, 0))
+                    this.localVariables.add(LocalVariableNode("mob", monsterDesc, "TM;", startLabel, endLabel, 1))
+                    this.localVariables.add(LocalVariableNode("speedModifier", "D", null, startLabel, endLabel, 2))
+                    this.localVariables.add(LocalVariableNode("attackIntervalMin", "I", null, startLabel, endLabel, 4))
+                    this.localVariables.add(LocalVariableNode("attackRadius", "F", null, startLabel, endLabel, 5))
                 }
                 classNode.methods.add(fallbackConstructor)
             }
@@ -95,50 +80,31 @@ object ModifiedCloneWorkaroundLoader {
                 replaceType(classNode, monsterType, mobType)
 
                 val fallbackConstructor = MethodNode(
-                    Opcodes.ACC_PUBLIC, "<init>", "(${monsterDesc}DF)V",
-                    "<M:$monsterDesc:$rangedAttackMob:${KiltRemapper.remapDescriptor("Lnet/minecraft/world/entity/monster/CrossbowAttackMob;")}>(TM;DF)V", null
-                ).apply {
+					Opcodes.ACC_PUBLIC,
+	                "<init>",
+	                "(${monsterDesc}DF)V",
+					"<M:$monsterDesc:$rangedAttackMob:${KiltRemapper.remapDescriptor("Lnet/minecraft/world/entity/monster/CrossbowAttackMob;")}>(TM;DF)V",
+	                null
+				).apply {
                     val startLabel = LabelNode()
                     this.instructions.add(startLabel)
                     this.instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
                     this.instructions.add(VarInsnNode(Opcodes.ALOAD, 1))
                     this.instructions.add(VarInsnNode(Opcodes.DLOAD, 2)) // Fun fact, double parameters take 2 variable slots.
                     this.instructions.add(VarInsnNode(Opcodes.FLOAD, 4))
-                    this.instructions.add(
-                        MethodInsnNode(
-                            Opcodes.INVOKESPECIAL, crossbowAttackGoalClone,
-                            "<init>", "(${mobDesc}DF)V"
-                        )
-                    )
+                    this.instructions.add(MethodInsnNode(
+                        Opcodes.INVOKESPECIAL, crossbowAttackGoalClone,
+                        "<init>", "(${mobDesc}DF)V"
+                    ))
                     this.instructions.add(LabelNode())
                     this.instructions.add(InsnNode(Opcodes.RETURN))
                     val endLabel = LabelNode()
                     this.instructions.add(endLabel)
 
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "this", "L$crossbowAttackGoalClone;", "L$crossbowAttackGoalClone<TT;>;",
-                            startLabel, endLabel, 0
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "mob", monsterDesc, "TM;",
-                            startLabel, endLabel, 1
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "speedModifier", "D", null,
-                            startLabel, endLabel, 2
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "attackRadius", "F", null,
-                            startLabel, endLabel, 4
-                        )
-                    )
+                    this.localVariables.add(LocalVariableNode("this", "L$crossbowAttackGoalClone;", "L$crossbowAttackGoalClone<TT;>;", startLabel, endLabel, 0))
+                    this.localVariables.add(LocalVariableNode("mob", monsterDesc, "TM;", startLabel, endLabel, 1))
+                    this.localVariables.add(LocalVariableNode("speedModifier", "D", null, startLabel, endLabel, 2))
+                    this.localVariables.add(LocalVariableNode("attackRadius", "F", null, startLabel, endLabel, 4))
                 }
                 classNode.methods.add(fallbackConstructor)
             }
@@ -146,7 +112,7 @@ object ModifiedCloneWorkaroundLoader {
     }
 
     fun load() {
-        TRANSFORMERS.forEach { it() }
+        TRANSFORMERS.forEach(Runnable::run)
         TRANSFORMERS.clear()
     }
 
@@ -170,9 +136,7 @@ object ModifiedCloneWorkaroundLoader {
 
     private fun mapHandle(handle: Handle, oldTypeName: String, newTypeName: String): Handle {
         if (handle.owner == oldTypeName) {
-            return Handle(
-                handle.tag, newTypeName, handle.name, handle.desc, handle.isInterface
-            )
+            return Handle(handle.tag, newTypeName, handle.name, handle.desc, handle.isInterface)
         }
         return handle
     }
@@ -207,16 +171,14 @@ object ModifiedCloneWorkaroundLoader {
             ClassTinkerers.addPostTransformation(targetClass) { classNode ->
                 originalNode = classNode
             }
+
+            // Create an empty class so we don't get ClassNotFoundException when classloading.
+            // Only the class name actually matters, they will all be overwritten during classloading.
+            // 52 is the class version used by Java 8: https://docs.oracle.com/javase/specs/jvms/se26/html/jvms-1.html#jvms-1.2-220
             val cw = ClassWriter(0)
-            cw.visit(
-                52,
-                Opcodes.ACC_PUBLIC,
-                cloneClass,
-                null,
-                "java/lang/Object",
-                null
-            )
+            cw.visit(52, Opcodes.ACC_PUBLIC, cloneClass, null, "java/lang/Object", null)
             ClassTinkerers.define(cloneClass, cw.toByteArray())
+
             ClassTinkerers.addPostTransformation(cloneClass) { classNode ->
                 Class.forName(targetClass.replace("/", ".")) // Classload it somehow so the transform always runs first
                 originalNode?.accept(classNode)
@@ -229,9 +191,9 @@ object ModifiedCloneWorkaroundLoader {
     }
 
     fun replaceType(
-        classNode: ClassNode,
-        oldType: String,
-        newType: String
+		classNode: ClassNode,
+	    oldType: String,
+	    newType: String
     ) {
         val oldDescriptor = "L$oldType;"
         val newDescriptor = "L$newType;"


### PR DESCRIPTION
This PR resolves the crash when NeoForge mods use RangedBowAttackGoal or RangedCrossbowAttackGoal with non-monster entities.

Basically, it copies the RangedBowAttackGoal and RangedCrossbowAttackGoal after they have been modified by mixins and coremods and remaps the NeoForge mods to use that instead. I also inject the fallback Monster constructor manually to the NeoForge clone since it would just cause issues for Fabric mods.

Note that while this should work with RangedCrossbowAttackGoal without any changes, we will need to clean up RangedBowAttackGoal a bit. One way to do that would be to revert the following commits:
- 2fbfb20a1e076bff336776b492bdb1c7c9ce43be
- b72ed9306591f1e9e7617da7615a5979fb438c12

I was thinking of doing that in a separate PR.

Would you like to keep the changes to [KiltEarlyRiser](https://github.com/KiltMC/Kilt/commit/2fbfb20a1e076bff336776b492bdb1c7c9ce43be#diff-05eb33b4653f494353e9b5e2b9b71cc889aa008a99277468ecb0b98fab636f97)?