### PR TITLE
Implement step height inject.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/EntityInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/EntityInject.java
@@ -61,7 +61,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -143,7 +142,16 @@ public abstract class EntityInject implements IForgeEntity, CapabilityProviderIn
         return original.call(instance, tagKey) || instance.collisionExtendsVertically(this.level(), pos, (Entity) (Object) this);
     }
 
-    // TODO: do we need to implement step height?
+    @WrapOperation(
+        method = "collide",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/entity/Entity;maxUpStep()F"
+        )
+    )
+    private float kilt$collide(Entity instance, Operation<Float> original) {
+        return kilt$getStepHeight(() -> original.call(instance));
+    }
 
     @Unique private final AtomicReference<BlockPos> kilt$primaryPos = new AtomicReference<>(null);
     @Unique private final AtomicReference<BlockPos> kilt$secondaryPos = new AtomicReference<>(null);


### PR DESCRIPTION
Turns out we do need the step height patch after all.
At least if we want Superb Warfare to work correctly.

Depends on https://github.com/KiltMC/NeoForge/pull/18 for full functionality.