### PR TITLE
Backport Relevant Server Injects from 1.21.1 + Added MarkDirtyMap

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/MinecraftServerInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/MinecraftServerInject.java
@@ -1,15 +1,12 @@
 // TRACKED HASH: 0a24b5b7aafa1b5d82426467010c877512d3e484
 package xyz.bluspring.kilt.forgeinjects.server;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
+import java.util.*;
 import java.util.function.BooleanSupplier;
 
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.injector.ModifyReceiver;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
@@ -21,40 +18,31 @@ import com.mojang.serialization.JsonOps;
 import net.minecraft.network.protocol.status.ServerStatus;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.level.Level;
+import net.minecraft.world.level.*;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fml.util.thread.SidedThreadGroups;
+import net.minecraftforge.gametest.ForgeGameTestHooks;
 import net.minecraftforge.network.ServerStatusPing;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.bluspring.kilt.injections.server.MinecraftServerInjection;
-import xyz.bluspring.kilt.injections.world.item.alchemy.PotionBrewingInjection;
 
 import net.minecraft.Util;
 import net.minecraft.core.RegistryAccess;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientboundSetTimePacket;
-import net.minecraft.network.protocol.status.ServerStatus;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
-import net.minecraft.world.flag.FeatureFlagSet;
-import net.minecraft.world.item.alchemy.PotionBrewing;
-import net.minecraft.world.level.ForcedChunksSavedData;
-import net.minecraft.world.level.GameRules;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.ServerLevelData;
 
 @Mixin(MinecraftServer.class)
 public abstract class MinecraftServerInject implements MinecraftServerInjection {
     @Shadow private MinecraftServer.ReloadableResources resources;
-    @Shadow public abstract RegistryAccess.Frozen registryAccess();
+    @Shadow
+    public abstract RegistryAccess.Frozen registryAccess();
     @Shadow public abstract PlayerList getPlayerList();
     @Shadow private int tickCount;
 
@@ -67,33 +55,16 @@ public abstract class MinecraftServerInject implements MinecraftServerInjection 
         return new Thread(SidedThreadGroups.SERVER, target, name);
     }
 
-    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/alchemy/PotionBrewing;bootstrap(Lnet/minecraft/world/flag/FeatureFlagSet;)Lnet/minecraft/world/item/alchemy/PotionBrewing;"))
-    private PotionBrewing kilt$addRegistryAccessToBrewingBootstrap(FeatureFlagSet enabledFeatures, Operation<PotionBrewing> original) {
-        try {
-            PotionBrewingInjection.kilt$registryAccess.set(this.registryAccess());
-            return original.call(enabledFeatures);
-        } finally {
-            PotionBrewingInjection.kilt$registryAccess.set(RegistryAccess.EMPTY);
-        }
-    }
-
     // Load Events implemented via Fabric API
 
     @Inject(method = "setInitialSpawn", at = @At(value = "NEW", target = "(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/ChunkPos;", ordinal = 0), cancellable = true)
     private static void kilt$checkCreateWorldSpawn(ServerLevel level, ServerLevelData levelData, boolean generateBonusChest, boolean debug, CallbackInfo ci) {
-        if (EventHooks.onCreateWorldSpawn(level, levelData)) {
+        if (ForgeEventFactory.onCreateWorldSpawn(level, levelData)) {
             ci.cancel();
         }
     }
 
-    @ModifyExpressionValue(method = "prepareLevels", at = @At(value = "INVOKE", target = "Lit/unimi/dsi/fastutil/longs/LongIterator;hasNext()Z"))
-    private boolean kilt$tryReinstatePersistentChunks(boolean original, @Local(ordinal = 1) ServerLevel level, @Local ForcedChunksSavedData savedData) {
-        if (!original) {
-            ForcedChunkManager.reinstatePersistentChunks(level, savedData);
-        }
-
-        return original;
-    }
+    // ForgeChunkManager::reinstatePersistentChunks handled via Porting Lib
 
     // Kilt: unload and server lifecycle and tick events handled via Fabric API
 
@@ -118,12 +89,6 @@ public abstract class MinecraftServerInject implements MinecraftServerInjection 
     @ModifyReturnValue(method = "buildServerStatus", at = @At("RETURN"))
     private ServerStatus kilt$appendServerPing(ServerStatus original) {
         original.setForgeData(Optional.of(new ServerStatusPing()));
-        return original;
-    }
-    
-    @ModifyReturnValue(method = "buildServerStatus", at = @At("RETURN"))
-    private ServerStatus kilt$applyModdedServerToStatus(ServerStatus original) {
-        original.kilt$setModded(true);
         return original;
     }
 
@@ -151,36 +116,12 @@ public abstract class MinecraftServerInject implements MinecraftServerInjection 
 
     @ModifyExpressionValue(method = "tickChildren", at = @At(value = "FIELD", target = "Lnet/minecraft/SharedConstants;IS_RUNNING_IN_IDE:Z", opcode = Opcodes.GETSTATIC))
     private boolean kilt$checkIsGameTestEnabled(boolean original) {
-        return original || GameTestHooks.isGametestEnabled();
-    }
-
-    @WrapOperation(method = "synchronizeTime", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastAll(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/resources/ResourceKey;)V"))
-    private void kilt$trySynchronizeWithNeoPacket(PlayerList instance, Packet<?> packet, ResourceKey<Level> dimension, Operation<Void> original, @Local(argsOnly = true) ServerLevel level) {
-        if (packet instanceof ClientboundSetTimePacket originalPacket) {
-            var neoPacket = new ClientboundCustomSetTimePayload(originalPacket.getGameTime(), originalPacket.getDayTime(), level.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT), level.getDayTimeFraction(), level.getDayTimePerTick());
-            for (ServerPlayer player : this.getPlayerList().getPlayers()) {
-                if (player.level().dimension() == dimension) {
-                    if (player.connection.hasChannel(ClientboundCustomSetTimePayload.TYPE)) {
-                        player.connection.send(neoPacket);
-                    } else {
-                        player.connection.send(originalPacket);
-                    }
-                }
-            }
-        } else {
-            original.call(instance, packet, dimension);
-        }
+        return original || ForgeGameTestHooks.isGametestEnabled();
     }
 
     @ModifyReturnValue(method = "getServerModName", at = @At("RETURN"), remap = false)
     private String kilt$appendKiltToServerBranding(String original) {
         return original + " + kilt";
-    }
-
-    @ModifyReceiver(method = "method_29442", at = @At(value = "INVOKE", target = "Ljava/util/Collection;stream()Ljava/util/stream/Stream;"))
-    private Collection<?> kilt$tryRebuildSelected(Collection<?> instance) {
-        // Kilt TODO: do we need this?
-        return instance;
     }
 
     @Inject(method = "method_29440", at = @At("TAIL"))

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/MinecraftServerInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/MinecraftServerInject.java
@@ -1,6 +1,7 @@
 // TRACKED HASH: 0a24b5b7aafa1b5d82426467010c877512d3e484
 package xyz.bluspring.kilt.forgeinjects.server;
 
+import java.net.Proxy;
 import java.util.*;
 import java.util.function.BooleanSupplier;
 
@@ -8,28 +9,30 @@ import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalLongRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import com.mojang.datafixers.DataFixer;
 import com.mojang.serialization.JsonOps;
 import net.minecraft.network.protocol.status.ServerStatus;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.Services;
+import net.minecraft.server.WorldStem;
+import net.minecraft.server.level.progress.ChunkProgressListenerFactory;
+import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.world.level.*;
+import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fml.util.thread.SidedThreadGroups;
 import net.minecraftforge.gametest.ForgeGameTestHooks;
 import net.minecraftforge.network.ServerStatusPing;
 import org.objectweb.asm.Opcodes;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import xyz.bluspring.kilt.helpers.MarkDirtyMap;
 import xyz.bluspring.kilt.injections.server.MinecraftServerInjection;
 
 import net.minecraft.Util;
@@ -48,6 +51,7 @@ public abstract class MinecraftServerInject implements MinecraftServerInjection 
 
     @Shadow
     @Final
+    @Mutable
     private Map<ResourceKey<Level>, ServerLevel> levels;
 
     @Redirect(method = "spin", at = @At(value = "NEW", target = "java/lang/Thread"))
@@ -92,13 +96,21 @@ public abstract class MinecraftServerInject implements MinecraftServerInjection 
         return original;
     }
 
-    @WrapOperation(method = "tickChildren", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;getAllLevels()Ljava/lang/Iterable;"))
-    private Iterable<ServerLevel> kilt$tryGetAllLevelsFromArray(MinecraftServer instance, Operation<Iterable<ServerLevel>> original) {
-        if (this.worldArrayLast != -1) { // Kilt: This path will only appear if a mod calls markWorldsDirty once at some point.
-            return Arrays.asList(this.getWorldArray());
-        }
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void kilt$prepareAutomaticDirtyMarker(Thread serverThread, LevelStorageSource.LevelStorageAccess storageSource, PackRepository packRepository, WorldStem worldStem, Proxy proxy, DataFixer fixerUpper, Services services, ChunkProgressListenerFactory progressListenerFactory, CallbackInfo ci) {
+        levels = new MarkDirtyMap<>(levels, this::markWorldsDirty);
+    }
 
-        return original.call(instance);
+    @Inject(method = "tickChildren", at = @At("HEAD"))
+    private void kilt$checkAutomaticDirtyMarker(BooleanSupplier hasTimeLeft, CallbackInfo ci) {
+        if (!(levels instanceof MarkDirtyMap<ResourceKey<Level>, ServerLevel>)) {
+            levels = new MarkDirtyMap<>(levels, this::markWorldsDirty);
+        }
+    }
+
+    @Redirect(method = "tickChildren", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;getAllLevels()Ljava/lang/Iterable;"))
+    private Iterable<ServerLevel> kilt$tryGetAllLevelsFromArray(MinecraftServer instance) {
+        return Arrays.asList(this.getWorldArray());
     }
 
     @Inject(method = "tickChildren", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/util/function/Supplier;)V", ordinal = 0))

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/MinecraftServerInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/MinecraftServerInject.java
@@ -1,10 +1,22 @@
 // TRACKED HASH: 0a24b5b7aafa1b5d82426467010c877512d3e484
 package xyz.bluspring.kilt.forgeinjects.server;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.ModifyReceiver;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalLongRef;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import com.mojang.serialization.JsonOps;
 import net.minecraft.network.protocol.status.ServerStatus;
 import net.minecraft.resources.ResourceKey;
@@ -15,41 +27,87 @@ import net.minecraftforge.network.ServerStatusPing;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.bluspring.kilt.injections.server.MinecraftServerInjection;
+import xyz.bluspring.kilt.injections.world.item.alchemy.PotionBrewingInjection;
 
-import java.util.Map;
-import java.util.Optional;
+import net.minecraft.Util;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundSetTimePacket;
+import net.minecraft.network.protocol.status.ServerStatus;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
+import net.minecraft.world.flag.FeatureFlagSet;
+import net.minecraft.world.item.alchemy.PotionBrewing;
+import net.minecraft.world.level.ForcedChunksSavedData;
+import net.minecraft.world.level.GameRules;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.storage.ServerLevelData;
 
 @Mixin(MinecraftServer.class)
-public class MinecraftServerInject implements MinecraftServerInjection {
-    private Map<ResourceKey<Level>, long[]> perWorldTickTimes = Maps.newIdentityHashMap();
+public abstract class MinecraftServerInject implements MinecraftServerInjection {
+    @Shadow private MinecraftServer.ReloadableResources resources;
+    @Shadow public abstract RegistryAccess.Frozen registryAccess();
+    @Shadow public abstract PlayerList getPlayerList();
+    @Shadow private int tickCount;
 
-    @Override
-    public long[] getTickTime(ResourceKey<Level> dim) {
-        return perWorldTickTimes.get(dim);
-    }
-
-    @ModifyReturnValue(method = "getServerModName", at = @At("RETURN"), remap = false)
-    private String kilt$appendKiltToServerBranding(String original) {
-        return original + " + kilt";
-    }
+    @Shadow
+    @Final
+    private Map<ResourceKey<Level>, ServerLevel> levels;
 
     @Redirect(method = "spin", at = @At(value = "NEW", target = "java/lang/Thread"))
     private static Thread kilt$setThreadGroup(Runnable target, String name) {
         return new Thread(SidedThreadGroups.SERVER, target, name);
     }
 
-    @Unique private static final Gson GSON = new Gson();
-    @Unique private String cachedServerStatus;
-    @Unique private void resetStatusCache(ServerStatus status) {
-        this.cachedServerStatus = GSON.toJson(ServerStatus.CODEC.encodeStart(JsonOps.INSTANCE, status).result().orElseThrow());
+    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/alchemy/PotionBrewing;bootstrap(Lnet/minecraft/world/flag/FeatureFlagSet;)Lnet/minecraft/world/item/alchemy/PotionBrewing;"))
+    private PotionBrewing kilt$addRegistryAccessToBrewingBootstrap(FeatureFlagSet enabledFeatures, Operation<PotionBrewing> original) {
+        try {
+            PotionBrewingInjection.kilt$registryAccess.set(this.registryAccess());
+            return original.call(enabledFeatures);
+        } finally {
+            PotionBrewingInjection.kilt$registryAccess.set(RegistryAccess.EMPTY);
+        }
     }
+
+    // Load Events implemented via Fabric API
+
+    @Inject(method = "setInitialSpawn", at = @At(value = "NEW", target = "(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/ChunkPos;", ordinal = 0), cancellable = true)
+    private static void kilt$checkCreateWorldSpawn(ServerLevel level, ServerLevelData levelData, boolean generateBonusChest, boolean debug, CallbackInfo ci) {
+        if (EventHooks.onCreateWorldSpawn(level, levelData)) {
+            ci.cancel();
+        }
+    }
+
+    @ModifyExpressionValue(method = "prepareLevels", at = @At(value = "INVOKE", target = "Lit/unimi/dsi/fastutil/longs/LongIterator;hasNext()Z"))
+    private boolean kilt$tryReinstatePersistentChunks(boolean original, @Local(ordinal = 1) ServerLevel level, @Local ForcedChunksSavedData savedData) {
+        if (!original) {
+            ForcedChunkManager.reinstatePersistentChunks(level, savedData);
+        }
+
+        return original;
+    }
+
+    // Kilt: unload and server lifecycle and tick events handled via Fabric API
 
     @ModifyExpressionValue(method = "tickServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;buildServerStatus()Lnet/minecraft/network/protocol/status/ServerStatus;"))
     private ServerStatus kilt$resetStatusCache(ServerStatus original) {
         this.resetStatusCache(original);
         return original;
+    }
+
+    @Unique private static final Gson GSON = new Gson();
+    @Unique private String cachedServerStatus;
+    @Unique private void resetStatusCache(ServerStatus status) {
+        this.cachedServerStatus = GSON.toJson(ServerStatus.CODEC.encodeStart(JsonOps.INSTANCE, status)
+            .result().orElseThrow());
     }
 
     @Override
@@ -62,6 +120,109 @@ public class MinecraftServerInject implements MinecraftServerInjection {
         original.setForgeData(Optional.of(new ServerStatusPing()));
         return original;
     }
+    
+    @ModifyReturnValue(method = "buildServerStatus", at = @At("RETURN"))
+    private ServerStatus kilt$applyModdedServerToStatus(ServerStatus original) {
+        original.kilt$setModded(true);
+        return original;
+    }
 
-    // Tick Events implemented via Architectury
+    @WrapOperation(method = "tickChildren", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;getAllLevels()Ljava/lang/Iterable;"))
+    private Iterable<ServerLevel> kilt$tryGetAllLevelsFromArray(MinecraftServer instance, Operation<Iterable<ServerLevel>> original) {
+        if (this.worldArrayLast != -1) { // Kilt: This path will only appear if a mod calls markWorldsDirty once at some point.
+            return Arrays.asList(this.getWorldArray());
+        }
+
+        return original.call(instance);
+    }
+
+    @Inject(method = "tickChildren", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/util/function/Supplier;)V", ordinal = 0))
+    private void kilt$storeCurrentLevel(BooleanSupplier hasTimeLeft, CallbackInfo ci, @Local ServerLevel level, @Share("level") LocalRef<ServerLevel> levelRef, @Share("tickStart") LocalLongRef tickStartRef) {
+        levelRef.set(level);
+        tickStartRef.set(Util.getNanos());
+    }
+
+    @Inject(method = "tickChildren", slice = @Slice(from = @At(value = "CONSTANT", args = "stringValue=tick"), to = @At(value = "CONSTANT", args = "stringValue=connection")), at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;pop()V", ordinal = 0))
+    private void kilt$tryHandlePerWorldTickTimes(BooleanSupplier hasTimeLeft, CallbackInfo ci, @Share("level") LocalRef<ServerLevel> levelRef,  @Share("tickStart") LocalLongRef tickStartRef) {
+        if (levelRef.get() != null) {
+            this.perWorldTickTimes.computeIfAbsent(levelRef.get().dimension(), k -> new long[100])[this.tickCount % 100] = Util.getNanos() - tickStartRef.get();
+        }
+    }
+
+    @ModifyExpressionValue(method = "tickChildren", at = @At(value = "FIELD", target = "Lnet/minecraft/SharedConstants;IS_RUNNING_IN_IDE:Z", opcode = Opcodes.GETSTATIC))
+    private boolean kilt$checkIsGameTestEnabled(boolean original) {
+        return original || GameTestHooks.isGametestEnabled();
+    }
+
+    @WrapOperation(method = "synchronizeTime", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastAll(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/resources/ResourceKey;)V"))
+    private void kilt$trySynchronizeWithNeoPacket(PlayerList instance, Packet<?> packet, ResourceKey<Level> dimension, Operation<Void> original, @Local(argsOnly = true) ServerLevel level) {
+        if (packet instanceof ClientboundSetTimePacket originalPacket) {
+            var neoPacket = new ClientboundCustomSetTimePayload(originalPacket.getGameTime(), originalPacket.getDayTime(), level.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT), level.getDayTimeFraction(), level.getDayTimePerTick());
+            for (ServerPlayer player : this.getPlayerList().getPlayers()) {
+                if (player.level().dimension() == dimension) {
+                    if (player.connection.hasChannel(ClientboundCustomSetTimePayload.TYPE)) {
+                        player.connection.send(neoPacket);
+                    } else {
+                        player.connection.send(originalPacket);
+                    }
+                }
+            }
+        } else {
+            original.call(instance, packet, dimension);
+        }
+    }
+
+    @ModifyReturnValue(method = "getServerModName", at = @At("RETURN"), remap = false)
+    private String kilt$appendKiltToServerBranding(String original) {
+        return original + " + kilt";
+    }
+
+    @ModifyReceiver(method = "method_29442", at = @At(value = "INVOKE", target = "Ljava/util/Collection;stream()Ljava/util/stream/Stream;"))
+    private Collection<?> kilt$tryRebuildSelected(Collection<?> instance) {
+        // Kilt TODO: do we need this?
+        return instance;
+    }
+
+    @Inject(method = "method_29440", at = @At("TAIL"))
+    private void kilt$fixCommandsNotUpdating(Collection collection, MinecraftServer.ReloadableResources reloadableResources, CallbackInfo ci) {
+        this.getPlayerList().getPlayers().forEach(this.getPlayerList()::sendPlayerPermissionLevel);
+    }
+
+    // Kilt TODO: do we need pack stuff?
+
+    @Unique private Map<ResourceKey<Level>, long[]> perWorldTickTimes = Maps.newIdentityHashMap();
+
+    @Override
+    public long[] getTickTime(ResourceKey<Level> dim) {
+        return perWorldTickTimes.get(dim);
+    }
+
+    public synchronized Map<ResourceKey<Level>, ServerLevel> forgeGetWorldMap() {
+        return this.levels;
+    }
+
+    @Unique private int worldArrayMarker = 0;
+    @Unique private int worldArrayLast = -1;
+    @Unique private ServerLevel[] worldArray;
+
+    public synchronized void markWorldsDirty() {
+        worldArrayMarker++;
+    }
+
+    @Unique
+    private ServerLevel[] getWorldArray() {
+        if (this.worldArrayMarker == this.worldArrayLast && this.worldArray != null)
+            return this.worldArray;
+
+        this.worldArray = this.levels.values().toArray(new ServerLevel[0]);
+        this.worldArrayLast = this.worldArrayMarker;
+        return this.worldArray;
+    }
+
+    @Override
+    public MinecraftServer.ReloadableResources getServerResources() {
+        return this.resources;
+    }
+
+    // Tick Events implemented via Fabric API
 }

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/MinecraftServerInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/MinecraftServerInject.java
@@ -74,9 +74,12 @@ public abstract class MinecraftServerInject implements MinecraftServerInjection 
         return original;
     }
 
-    @Unique private static final Gson GSON = new Gson();
-    @Unique private String cachedServerStatus;
-    @Unique private void resetStatusCache(ServerStatus status) {
+    @Unique
+    private static final Gson GSON = new Gson();
+    @Unique
+    private String cachedServerStatus;
+    @Unique
+    private void resetStatusCache(ServerStatus status) {
         this.cachedServerStatus = GSON.toJson(ServerStatus.CODEC.encodeStart(JsonOps.INSTANCE, status)
             .result().orElseThrow());
     }
@@ -139,7 +142,8 @@ public abstract class MinecraftServerInject implements MinecraftServerInjection 
 
     // Kilt TODO: do we need pack stuff?
 
-    @Unique private Map<ResourceKey<Level>, long[]> perWorldTickTimes = Maps.newIdentityHashMap();
+    @Unique
+    private Map<ResourceKey<Level>, long[]> perWorldTickTimes = Maps.newIdentityHashMap();
 
     @Override
     public long[] getTickTime(ResourceKey<Level> dim) {

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/server/MinecraftServerInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/server/MinecraftServerInject.java
@@ -44,15 +44,11 @@ import net.minecraft.world.level.storage.ServerLevelData;
 @Mixin(MinecraftServer.class)
 public abstract class MinecraftServerInject implements MinecraftServerInjection {
     @Shadow private MinecraftServer.ReloadableResources resources;
-    @Shadow
-    public abstract RegistryAccess.Frozen registryAccess();
+    @Shadow public abstract RegistryAccess.Frozen registryAccess();
     @Shadow public abstract PlayerList getPlayerList();
     @Shadow private int tickCount;
 
-    @Shadow
-    @Final
-    @Mutable
-    private Map<ResourceKey<Level>, ServerLevel> levels;
+    @Shadow @Final @Mutable private Map<ResourceKey<Level>, ServerLevel> levels;
 
     @Redirect(method = "spin", at = @At(value = "NEW", target = "java/lang/Thread"))
     private static Thread kilt$setThreadGroup(Runnable target, String name) {
@@ -150,13 +146,17 @@ public abstract class MinecraftServerInject implements MinecraftServerInjection 
         return perWorldTickTimes.get(dim);
     }
 
+    @Override
     public synchronized Map<ResourceKey<Level>, ServerLevel> forgeGetWorldMap() {
         return this.levels;
     }
 
-    @Unique private int worldArrayMarker = 0;
-    @Unique private int worldArrayLast = -1;
-    @Unique private ServerLevel[] worldArray;
+    @Unique
+    private int worldArrayMarker = 0;
+    @Unique
+    private int worldArrayLast = -1;
+    @Unique
+    private ServerLevel[] worldArray;
 
     public synchronized void markWorldsDirty() {
         worldArrayMarker++;

--- a/src/main/java/xyz/bluspring/kilt/helpers/MarkDirtyMap.java
+++ b/src/main/java/xyz/bluspring/kilt/helpers/MarkDirtyMap.java
@@ -1,0 +1,494 @@
+package xyz.bluspring.kilt.helpers;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.Stream;
+
+// Custom wrapping map implementation which runs `markDirtyFunction` whenever modified in any way.
+public class MarkDirtyMap<K, V> implements Map<K, V> {
+
+    private final Map<K, V> parent;
+    private final Runnable markDirtyFunction;
+
+    public MarkDirtyMap(Map<K, V> parent, Runnable markDirtyFunction) {
+        this.parent = parent;
+        this.markDirtyFunction = markDirtyFunction;
+    }
+
+    public void markDirty() {
+        this.markDirtyFunction.run();
+    }
+
+    private <T> T markDirtyAfter(Supplier<T> runner, T newValue) {
+        return markDirtyAfter(runner, newValue, true);
+    }
+
+    private <T> T markDirtyAfter(Supplier<T> runner, T newValue, boolean extraCondition) {
+        var oldValue = runner.get();
+        if (newValue != oldValue && extraCondition) {
+            markDirty();
+        }
+        return oldValue;
+    }
+
+    private <T> T markDirtyAfter(Supplier<T> runner) {
+        var oldValue = runner.get();
+        markDirty();
+        return oldValue;
+    }
+
+    private boolean markDirtyAfter(BooleanSupplier runner) {
+        if (runner.getAsBoolean()) {
+            markDirty();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private void markDirtyIf(Runnable runner, boolean shouldMarkDirty) {
+        runner.run();
+        if (shouldMarkDirty) {
+            markDirty();
+        }
+    }
+
+    private <T> T markDirtyIf(Supplier<T> runner, boolean shouldMarkDirty) {
+        var result = runner.get();
+        if (shouldMarkDirty) {
+            markDirty();
+        }
+        return result;
+    }
+
+    @Override
+    public int size() {
+        return parent.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return parent.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return parent.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return parent.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return parent.get(key);
+    }
+
+    @Override
+    public @Nullable V put(K key, V value) {
+        return markDirtyAfter(() -> parent.put(key, value), value);
+    }
+
+    @Override
+    public V remove(Object key) {
+        return markDirtyAfter(() -> parent.remove(key), null);
+    }
+
+    @Override
+    public void putAll(@NotNull Map<? extends K, ? extends V> m) {
+        markDirtyIf(() -> parent.putAll(m), !m.isEmpty());
+    }
+
+    @Override
+    public void clear() {
+        markDirtyIf(parent::clear, !isEmpty());
+    }
+
+    @Override
+    public @NotNull Set<K> keySet() {
+        return new MarkDirtySet<>(parent.keySet());
+    }
+
+    @Override
+    public @NotNull Collection<V> values() {
+        return new MarkDirtyCollection<>(parent.values());
+    }
+
+    @Override
+    public @NotNull Set<Entry<K, V>> entrySet() {
+        return new MarkDirtyEntrySet(parent.entrySet());
+    }
+
+    @Override
+    public V getOrDefault(Object key, V defaultValue) {
+        return parent.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super K, ? super V> action) {
+        parent.forEach(action);
+    }
+
+    @Override
+    public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        parent.replaceAll(function);
+        markDirty();
+    }
+
+    @Override
+    public @Nullable V putIfAbsent(K key, V value) {
+        return markDirtyAfter(() -> putIfAbsent(key, value), value, !containsKey(key));
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        return markDirtyAfter(() -> parent.remove(key, value));
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        return markDirtyAfter(() -> parent.replace(key, oldValue, newValue));
+    }
+
+    @Override
+    public @Nullable V replace(K key, V value) {
+        return markDirtyAfter(() -> parent.replace(key, value), value, containsKey(key));
+    }
+
+    @Override
+    public V computeIfAbsent(K key, @NotNull Function<? super K, ? extends V> mappingFunction) {
+        return markDirtyIf(() -> parent.computeIfAbsent(key, mappingFunction), !containsKey(key));
+    }
+
+    @Override
+    public V computeIfPresent(K key, @NotNull BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return markDirtyIf(() -> parent.computeIfPresent(key, remappingFunction), containsKey(key));
+    }
+
+    @Override
+    public V compute(K key, @NotNull BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return markDirtyAfter(() -> parent.compute(key, remappingFunction));
+    }
+
+    @Override
+    public V merge(K key, @NotNull V value, @NotNull BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return markDirtyAfter(() -> parent.merge(key, value, remappingFunction));
+    }
+
+    public class MarkDirtyIterator<T> implements Iterator<T> {
+
+        private final Iterator<T> parent;
+
+        private MarkDirtyIterator(Iterator<T> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return parent.hasNext();
+        }
+
+        @Override
+        public T next() {
+            return parent.next();
+        }
+
+        @Override
+        public void remove() {
+            parent.remove();
+            markDirty();
+        }
+
+        @Override
+        public void forEachRemaining(Consumer<? super T> action) {
+            parent.forEachRemaining(action);
+        }
+    }
+
+    public class MarkDirtyCollection<T> implements Collection<T> {
+
+        protected final Collection<T> parent;
+
+        public MarkDirtyCollection(Collection<T> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public int size() {
+            return parent.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return parent.isEmpty();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return parent.contains(o);
+        }
+
+        @Override
+        public @NotNull Iterator<T> iterator() {
+            return new MarkDirtyIterator<>(parent.iterator());
+        }
+
+        @Override
+        public void forEach(Consumer<? super T> action) {
+            parent.forEach(action);
+        }
+
+        @Override
+        public @NotNull Object @NotNull [] toArray() {
+            return parent.toArray();
+        }
+
+        @Override
+        public @NotNull <T1> T1 @NotNull [] toArray(@NotNull T1 @NotNull [] a) {
+            return parent.toArray(a);
+        }
+
+        @Override
+        public <T1> T1[] toArray(@NotNull IntFunction<T1[]> generator) {
+            return parent.toArray(generator);
+        }
+
+        @Override
+        public boolean add(T t) {
+            return markDirtyAfter(() -> parent.add(t));
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            return markDirtyAfter(() -> parent.remove(o));
+        }
+
+        @Override
+        public boolean containsAll(@NotNull Collection<?> c) {
+            return parent.containsAll(c);
+        }
+
+        @Override
+        public boolean addAll(@NotNull Collection<? extends T> c) {
+            return markDirtyAfter(() -> parent.addAll(c));
+        }
+
+        @Override
+        public boolean removeAll(@NotNull Collection<?> c) {
+            return markDirtyAfter(() -> parent.removeAll(c));
+        }
+
+        @Override
+        public boolean removeIf(@NotNull Predicate<? super T> filter) {
+            return markDirtyAfter(() -> parent.removeIf(filter));
+        }
+
+        @Override
+        public boolean retainAll(@NotNull Collection<?> c) {
+            return markDirtyAfter(() -> parent.retainAll(c));
+        }
+
+        @Override
+        public void clear() {
+            markDirtyIf(parent::clear, !isEmpty());
+        }
+
+        @Override
+        public @NotNull Spliterator<T> spliterator() {
+            return parent.spliterator();
+        }
+
+        @Override
+        public @NotNull Stream<T> stream() {
+            return parent.stream();
+        }
+
+        @Override
+        public @NotNull Stream<T> parallelStream() {
+            return parent.parallelStream();
+        }
+    }
+
+    public class MarkDirtySet<T> extends MarkDirtyCollection<T> implements Set<T> {
+        public MarkDirtySet(Set<T> parent) {
+            super(parent);
+        }
+    }
+
+    public class MarkDirtyEntry implements Entry<K, V> {
+
+        private final Entry<K, V> parent;
+
+        public MarkDirtyEntry(Entry<K, V> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public K getKey() {
+            return parent.getKey();
+        }
+
+        @Override
+        public V getValue() {
+            return parent.getValue();
+        }
+
+        @Override
+        public V setValue(V value) {
+            return markDirtyAfter(() -> parent.setValue(value), value);
+        }
+    }
+
+    public class MarkDirtyEntrySet extends MarkDirtySet<Entry<K, V>> {
+
+        public MarkDirtyEntrySet(Set<Entry<K, V>> parent) {
+            super(parent);
+        }
+
+        public class MarkDirtyEntrySetIterator implements Iterator<Entry<K, V>> {
+
+            private final Iterator<Entry<K, V>> parent;
+
+            public MarkDirtyEntrySetIterator(Iterator<Entry<K, V>> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return parent.hasNext();
+            }
+
+            @Override
+            public Entry<K, V> next() {
+                var next = parent.next();
+                if (next == null) return null;
+                return new MarkDirtyEntry(next);
+            }
+
+            @Override
+            public void remove() {
+                parent.remove();
+            }
+
+            @Override
+            public void forEachRemaining(Consumer<? super Entry<K, V>> action) {
+                parent.forEachRemaining(e -> action.accept(new MarkDirtyEntry(e)));
+            }
+        }
+
+        @Override
+        public @NotNull Iterator<Entry<K, V>> iterator() {
+            return new MarkDirtyEntrySetIterator(super.iterator());
+        }
+
+        @Override
+        public void forEach(Consumer<? super Entry<K, V>> action) {
+            super.forEach(e -> action.accept(new MarkDirtyEntry(e)));
+        }
+
+        private void fixArray(Object[] array) {
+            for (int i = 0; i < array.length; i++) {
+                if (array[i] instanceof Map.Entry<?,?> entry && !(array[i] instanceof MarkDirtyMap<?,?>.MarkDirtyEntry)) {
+                    //noinspection unchecked
+                    array[i] = new MarkDirtyEntry((Map.Entry<K,V>) entry);
+                }
+            }
+        }
+
+        @Override
+        public @NotNull Object @NotNull [] toArray() {
+            var array = super.toArray();
+            fixArray(array);
+            return array;
+        }
+
+        @Override
+        public @NotNull <T> T @NotNull [] toArray(@NotNull T @NotNull [] a) {
+            var array = super.toArray(a);
+            fixArray(array);
+            return array;
+        }
+
+        @Override
+        public <T> T[] toArray(@NotNull IntFunction<T[]> generator) {
+            var array = super.toArray(generator);
+            fixArray(array);
+            return array;
+        }
+
+        @Override
+        public boolean removeIf(@NotNull Predicate<? super Entry<K, V>> filter) {
+            return super.removeIf(e -> filter.test(new MarkDirtyEntry(e)));
+        }
+
+        public class MarkDirtyEntrySetSpliterator implements Spliterator<Entry<K, V>> {
+
+            private final Spliterator<Entry<K, V>> parent;
+
+            public MarkDirtyEntrySetSpliterator(Spliterator<Entry<K, V>> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public boolean tryAdvance(Consumer<? super Entry<K, V>> action) {
+                return parent.tryAdvance(e -> action.accept(new MarkDirtyEntry(e)));
+            }
+
+            @Override
+            public void forEachRemaining(Consumer<? super Entry<K, V>> action) {
+                parent.forEachRemaining(e -> action.accept(new MarkDirtyEntry(e)));
+            }
+
+            @Override
+            public Spliterator<Entry<K, V>> trySplit() {
+                return new MarkDirtyEntrySetSpliterator(parent.trySplit());
+            }
+
+            @Override
+            public long estimateSize() {
+                return parent.estimateSize();
+            }
+
+            @Override
+            public long getExactSizeIfKnown() {
+                return parent.getExactSizeIfKnown();
+            }
+
+            @Override
+            public int characteristics() {
+                return parent.characteristics();
+            }
+
+            @Override
+            public boolean hasCharacteristics(int characteristics) {
+                return parent.hasCharacteristics(characteristics);
+            }
+
+            @Override
+            public Comparator<? super Entry<K, V>> getComparator() {
+                return parent.getComparator();
+            }
+        }
+
+        @Override
+        public @NotNull Spliterator<Entry<K, V>> spliterator() {
+            return new MarkDirtyEntrySetSpliterator(super.spliterator());
+        }
+
+        @Override
+        public @NotNull Stream<Entry<K, V>> stream() {
+            return super.stream().map(MarkDirtyEntry::new);
+        }
+
+        @Override
+        public @NotNull Stream<Entry<K, V>> parallelStream() {
+            return super.parallelStream().map(MarkDirtyEntry::new);
+        }
+    }
+
+}

--- a/src/main/java/xyz/bluspring/kilt/helpers/MarkDirtyMap.java
+++ b/src/main/java/xyz/bluspring/kilt/helpers/MarkDirtyMap.java
@@ -11,57 +11,11 @@ import java.util.stream.Stream;
 public class MarkDirtyMap<K, V> implements Map<K, V> {
 
     private final Map<K, V> parent;
-    private final Runnable markDirtyFunction;
+    private final MarkDirtyContainer mdf;
 
-    public MarkDirtyMap(Map<K, V> parent, Runnable markDirtyFunction) {
+    public MarkDirtyMap(Map<K, V> parent, Runnable mdf) {
         this.parent = parent;
-        this.markDirtyFunction = markDirtyFunction;
-    }
-
-    public void markDirty() {
-        this.markDirtyFunction.run();
-    }
-
-    private <T> T markDirtyAfter(Supplier<T> runner, T newValue) {
-        return markDirtyAfter(runner, newValue, true);
-    }
-
-    private <T> T markDirtyAfter(Supplier<T> runner, T newValue, boolean extraCondition) {
-        var oldValue = runner.get();
-        if (newValue != oldValue && extraCondition) {
-            markDirty();
-        }
-        return oldValue;
-    }
-
-    private <T> T markDirtyAfter(Supplier<T> runner) {
-        var oldValue = runner.get();
-        markDirty();
-        return oldValue;
-    }
-
-    private boolean markDirtyAfter(BooleanSupplier runner) {
-        if (runner.getAsBoolean()) {
-            markDirty();
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    private void markDirtyIf(Runnable runner, boolean shouldMarkDirty) {
-        runner.run();
-        if (shouldMarkDirty) {
-            markDirty();
-        }
-    }
-
-    private <T> T markDirtyIf(Supplier<T> runner, boolean shouldMarkDirty) {
-        var result = runner.get();
-        if (shouldMarkDirty) {
-            markDirty();
-        }
-        return result;
+        this.mdf = new MarkDirtyContainer(mdf);
     }
 
     @Override
@@ -91,37 +45,37 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
 
     @Override
     public @Nullable V put(K key, V value) {
-        return markDirtyAfter(() -> parent.put(key, value), value);
+        return mdf.markDirtyAfter(() -> parent.put(key, value), value);
     }
 
     @Override
     public V remove(Object key) {
-        return markDirtyAfter(() -> parent.remove(key), null);
+        return mdf.markDirtyAfter(() -> parent.remove(key), null);
     }
 
     @Override
     public void putAll(@NotNull Map<? extends K, ? extends V> m) {
-        markDirtyIf(() -> parent.putAll(m), !m.isEmpty());
+        mdf.markDirtyIf(() -> parent.putAll(m), !m.isEmpty());
     }
 
     @Override
     public void clear() {
-        markDirtyIf(parent::clear, !isEmpty());
+        mdf.markDirtyIf(parent::clear, !isEmpty());
     }
 
     @Override
     public @NotNull Set<K> keySet() {
-        return new MarkDirtySet<>(parent.keySet());
+        return new MarkDirtySet<>(parent.keySet(), mdf);
     }
 
     @Override
     public @NotNull Collection<V> values() {
-        return new MarkDirtyCollection<>(parent.values());
+        return new MarkDirtyCollection<>(parent.values(), mdf);
     }
 
     @Override
     public @NotNull Set<Entry<K, V>> entrySet() {
-        return new MarkDirtyEntrySet(parent.entrySet());
+        return new MarkDirtyEntrySet<>(parent.entrySet(), mdf);
     }
 
     @Override
@@ -137,55 +91,107 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
     @Override
     public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
         parent.replaceAll(function);
-        markDirty();
+        mdf.markDirty();
     }
 
     @Override
     public @Nullable V putIfAbsent(K key, V value) {
-        return markDirtyAfter(() -> putIfAbsent(key, value), value, !containsKey(key));
+        return mdf.markDirtyAfter(() -> putIfAbsent(key, value), value, !containsKey(key));
     }
 
     @Override
     public boolean remove(Object key, Object value) {
-        return markDirtyAfter(() -> parent.remove(key, value));
+        return mdf.markDirtyAfter(() -> parent.remove(key, value));
     }
 
     @Override
     public boolean replace(K key, V oldValue, V newValue) {
-        return markDirtyAfter(() -> parent.replace(key, oldValue, newValue));
+        return mdf.markDirtyAfter(() -> parent.replace(key, oldValue, newValue));
     }
 
     @Override
     public @Nullable V replace(K key, V value) {
-        return markDirtyAfter(() -> parent.replace(key, value), value, containsKey(key));
+        return mdf.markDirtyAfter(() -> parent.replace(key, value), value, containsKey(key));
     }
 
     @Override
     public V computeIfAbsent(K key, @NotNull Function<? super K, ? extends V> mappingFunction) {
-        return markDirtyIf(() -> parent.computeIfAbsent(key, mappingFunction), !containsKey(key));
+        return mdf.markDirtyIf(() -> parent.computeIfAbsent(key, mappingFunction), !containsKey(key));
     }
 
     @Override
     public V computeIfPresent(K key, @NotNull BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-        return markDirtyIf(() -> parent.computeIfPresent(key, remappingFunction), containsKey(key));
+        return mdf.markDirtyIf(() -> parent.computeIfPresent(key, remappingFunction), containsKey(key));
     }
 
     @Override
     public V compute(K key, @NotNull BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-        return markDirtyAfter(() -> parent.compute(key, remappingFunction));
+        return mdf.markDirtyAfter(() -> parent.compute(key, remappingFunction));
     }
 
     @Override
     public V merge(K key, @NotNull V value, @NotNull BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
-        return markDirtyAfter(() -> parent.merge(key, value, remappingFunction));
+        return mdf.markDirtyAfter(() -> parent.merge(key, value, remappingFunction));
     }
 
-    public class MarkDirtyIterator<T> implements Iterator<T> {
+    public record MarkDirtyContainer(Runnable markDirtyFunction) {
+
+        public void markDirty() {
+            this.markDirtyFunction.run();
+        }
+
+        private <T> T markDirtyAfter(Supplier<T> runner, T newValue) {
+            return markDirtyAfter(runner, newValue, true);
+        }
+
+        private <T> T markDirtyAfter(Supplier<T> runner, T newValue, boolean extraCondition) {
+            var oldValue = runner.get();
+            if (newValue != oldValue && extraCondition) {
+                markDirty();
+            }
+            return oldValue;
+        }
+
+        private <T> T markDirtyAfter(Supplier<T> runner) {
+            var oldValue = runner.get();
+            markDirty();
+            return oldValue;
+        }
+
+        private boolean markDirtyAfter(BooleanSupplier runner) {
+            if (runner.getAsBoolean()) {
+                markDirty();
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        private void markDirtyIf(Runnable runner, boolean shouldMarkDirty) {
+            runner.run();
+            if (shouldMarkDirty) {
+                markDirty();
+            }
+        }
+
+        private <T> T markDirtyIf(Supplier<T> runner, boolean shouldMarkDirty) {
+            var result = runner.get();
+            if (shouldMarkDirty) {
+                markDirty();
+            }
+            return result;
+        }
+
+    }
+
+    public static class MarkDirtyIterator<T> implements Iterator<T> {
 
         private final Iterator<T> parent;
+        private final MarkDirtyContainer mdf;
 
-        private MarkDirtyIterator(Iterator<T> parent) {
+        private MarkDirtyIterator(Iterator<T> parent, MarkDirtyContainer mdf) {
             this.parent = parent;
+            this.mdf = mdf;
         }
 
         @Override
@@ -201,7 +207,7 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
         @Override
         public void remove() {
             parent.remove();
-            markDirty();
+            mdf.markDirty();
         }
 
         @Override
@@ -210,12 +216,14 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
         }
     }
 
-    public class MarkDirtyCollection<T> implements Collection<T> {
+    public static class MarkDirtyCollection<T> implements Collection<T> {
 
         protected final Collection<T> parent;
+        protected final MarkDirtyContainer mdf;
 
-        public MarkDirtyCollection(Collection<T> parent) {
+        public MarkDirtyCollection(Collection<T> parent, MarkDirtyContainer mdf) {
             this.parent = parent;
+            this.mdf = mdf;
         }
 
         @Override
@@ -235,7 +243,7 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
 
         @Override
         public @NotNull Iterator<T> iterator() {
-            return new MarkDirtyIterator<>(parent.iterator());
+            return new MarkDirtyIterator<>(parent.iterator(), mdf);
         }
 
         @Override
@@ -260,12 +268,12 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
 
         @Override
         public boolean add(T t) {
-            return markDirtyAfter(() -> parent.add(t));
+            return mdf.markDirtyAfter(() -> parent.add(t));
         }
 
         @Override
         public boolean remove(Object o) {
-            return markDirtyAfter(() -> parent.remove(o));
+            return mdf.markDirtyAfter(() -> parent.remove(o));
         }
 
         @Override
@@ -275,27 +283,27 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
 
         @Override
         public boolean addAll(@NotNull Collection<? extends T> c) {
-            return markDirtyAfter(() -> parent.addAll(c));
+            return mdf.markDirtyAfter(() -> parent.addAll(c));
         }
 
         @Override
         public boolean removeAll(@NotNull Collection<?> c) {
-            return markDirtyAfter(() -> parent.removeAll(c));
+            return mdf.markDirtyAfter(() -> parent.removeAll(c));
         }
 
         @Override
         public boolean removeIf(@NotNull Predicate<? super T> filter) {
-            return markDirtyAfter(() -> parent.removeIf(filter));
+            return mdf.markDirtyAfter(() -> parent.removeIf(filter));
         }
 
         @Override
         public boolean retainAll(@NotNull Collection<?> c) {
-            return markDirtyAfter(() -> parent.retainAll(c));
+            return mdf.markDirtyAfter(() -> parent.retainAll(c));
         }
 
         @Override
         public void clear() {
-            markDirtyIf(parent::clear, !isEmpty());
+            mdf.markDirtyIf(parent::clear, !isEmpty());
         }
 
         @Override
@@ -314,18 +322,20 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
         }
     }
 
-    public class MarkDirtySet<T> extends MarkDirtyCollection<T> implements Set<T> {
-        public MarkDirtySet(Set<T> parent) {
-            super(parent);
+    public static class MarkDirtySet<T> extends MarkDirtyCollection<T> implements Set<T> {
+        public MarkDirtySet(Set<T> parent, MarkDirtyContainer mdf) {
+            super(parent, mdf);
         }
     }
 
-    public class MarkDirtyEntry implements Entry<K, V> {
+    public static class MarkDirtyEntry<K ,V> implements Entry<K, V> {
 
         private final Entry<K, V> parent;
+        private final MarkDirtyContainer mdf;
 
-        public MarkDirtyEntry(Entry<K, V> parent) {
+        public MarkDirtyEntry(Entry<K, V> parent, MarkDirtyContainer mdf) {
             this.parent = parent;
+            this.mdf = mdf;
         }
 
         @Override
@@ -340,22 +350,24 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
 
         @Override
         public V setValue(V value) {
-            return markDirtyAfter(() -> parent.setValue(value), value);
+            return mdf.markDirtyAfter(() -> parent.setValue(value), value);
         }
     }
 
-    public class MarkDirtyEntrySet extends MarkDirtySet<Entry<K, V>> {
+    public static class MarkDirtyEntrySet<K, V> extends MarkDirtySet<Entry<K, V>> {
 
-        public MarkDirtyEntrySet(Set<Entry<K, V>> parent) {
-            super(parent);
+        public MarkDirtyEntrySet(Set<Entry<K, V>> parent, MarkDirtyContainer mdf) {
+            super(parent, mdf);
         }
 
-        public class MarkDirtyEntrySetIterator implements Iterator<Entry<K, V>> {
+        public static class MarkDirtyEntrySetIterator<K, V> implements Iterator<Entry<K, V>> {
 
             private final Iterator<Entry<K, V>> parent;
+            private final MarkDirtyContainer mdf;
 
-            public MarkDirtyEntrySetIterator(Iterator<Entry<K, V>> parent) {
+            public MarkDirtyEntrySetIterator(Iterator<Entry<K, V>> parent, MarkDirtyContainer mdf) {
                 this.parent = parent;
+                this.mdf = mdf;
             }
 
             @Override
@@ -367,7 +379,7 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
             public Entry<K, V> next() {
                 var next = parent.next();
                 if (next == null) return null;
-                return new MarkDirtyEntry(next);
+                return new MarkDirtyEntry<>(next, mdf);
             }
 
             @Override
@@ -377,25 +389,25 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
 
             @Override
             public void forEachRemaining(Consumer<? super Entry<K, V>> action) {
-                parent.forEachRemaining(e -> action.accept(new MarkDirtyEntry(e)));
+                parent.forEachRemaining(e -> action.accept(new MarkDirtyEntry<>(e, mdf)));
             }
         }
 
         @Override
         public @NotNull Iterator<Entry<K, V>> iterator() {
-            return new MarkDirtyEntrySetIterator(super.iterator());
+            return new MarkDirtyEntrySetIterator<>(super.iterator(), mdf);
         }
 
         @Override
         public void forEach(Consumer<? super Entry<K, V>> action) {
-            super.forEach(e -> action.accept(new MarkDirtyEntry(e)));
+            super.forEach(e -> action.accept(new MarkDirtyEntry<>(e, mdf)));
         }
 
         private void fixArray(Object[] array) {
             for (int i = 0; i < array.length; i++) {
-                if (array[i] instanceof Map.Entry<?,?> entry && !(array[i] instanceof MarkDirtyMap<?,?>.MarkDirtyEntry)) {
+                if (array[i] instanceof Map.Entry<?,?> entry && !(array[i] instanceof MarkDirtyMap.MarkDirtyEntry<?,?>)) {
                     //noinspection unchecked
-                    array[i] = new MarkDirtyEntry((Map.Entry<K,V>) entry);
+                    array[i] = new MarkDirtyEntry<>((Map.Entry<K,V>) entry, mdf);
                 }
             }
         }
@@ -423,10 +435,10 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
 
         @Override
         public boolean removeIf(@NotNull Predicate<? super Entry<K, V>> filter) {
-            return super.removeIf(e -> filter.test(new MarkDirtyEntry(e)));
+            return super.removeIf(e -> filter.test(new MarkDirtyEntry<>(e, mdf)));
         }
 
-        public class MarkDirtyEntrySetSpliterator implements Spliterator<Entry<K, V>> {
+        private class MarkDirtyEntrySetSpliterator implements Spliterator<Entry<K, V>> {
 
             private final Spliterator<Entry<K, V>> parent;
 
@@ -436,12 +448,12 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
 
             @Override
             public boolean tryAdvance(Consumer<? super Entry<K, V>> action) {
-                return parent.tryAdvance(e -> action.accept(new MarkDirtyEntry(e)));
+                return parent.tryAdvance(e -> action.accept(new MarkDirtyEntry<>(e, mdf)));
             }
 
             @Override
             public void forEachRemaining(Consumer<? super Entry<K, V>> action) {
-                parent.forEachRemaining(e -> action.accept(new MarkDirtyEntry(e)));
+                parent.forEachRemaining(e -> action.accept(new MarkDirtyEntry<>(e, mdf)));
             }
 
             @Override
@@ -482,12 +494,12 @@ public class MarkDirtyMap<K, V> implements Map<K, V> {
 
         @Override
         public @NotNull Stream<Entry<K, V>> stream() {
-            return super.stream().map(MarkDirtyEntry::new);
+            return super.stream().map(e -> new MarkDirtyEntry<>(e, mdf));
         }
 
         @Override
         public @NotNull Stream<Entry<K, V>> parallelStream() {
-            return super.parallelStream().map(MarkDirtyEntry::new);
+            return super.parallelStream().map(e -> new MarkDirtyEntry<>(e, mdf));
         }
     }
 

--- a/src/main/java/xyz/bluspring/kilt/injections/server/MinecraftServerInjection.java
+++ b/src/main/java/xyz/bluspring/kilt/injections/server/MinecraftServerInjection.java
@@ -1,6 +1,12 @@
 package xyz.bluspring.kilt.injections.server;
 
+import java.util.Map;
+
+import xyz.bluspring.kilt.util.KiltHelper;
+
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 
 public interface MinecraftServerInjection {
@@ -10,5 +16,17 @@ public interface MinecraftServerInjection {
 
     default String getStatusJson() {
         throw new IllegalStateException();
+    }
+
+    default MinecraftServer.ReloadableResources getServerResources() {
+        throw KiltHelper.createMixinException(MinecraftServerInjection.class, "getServerResources");
+    }
+
+    default Map<ResourceKey<Level>, ServerLevel> forgeGetWorldMap() {
+        throw KiltHelper.createMixinException(MinecraftServerInjection.class, "forgeGetWorldMap");
+    }
+
+    default void markWorldsDirty() {
+        throw KiltHelper.createMixinException(MinecraftServerInjection.class, "markWorldsDirty");
     }
 }

--- a/src/main/kotlin/xyz/bluspring/kilt/util/KiltHelper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/KiltHelper.kt
@@ -222,4 +222,9 @@ object KiltHelper {
 
         throw exception
     }
+
+    @JvmStatic
+    fun createMixinException(injection: Class<*>, methodName: String): RuntimeException {
+        return RuntimeException("Go yell at Naz, he forgot to implement ${injection.simpleName}#$methodName")
+    }
 }


### PR DESCRIPTION
Essentially just a backport of 3927e784d24409b66751d307b9ed1d8fa106a59c to 1.20.1.

But I noticed that the [Tardis Mod](https://modrinth.com/mod/tardis-mod) would crash with a ConcurrentModificationException when an interior dimension was created, so I made Kilt always use the world array. To make sure Fabric mods update the world array properly, we now have a MarkDirtyMap which wraps basically every single edge case where the map is modified that I could think of and runs the mark dirty function. This technically makes the Forge markDirty function redundant though. What I do know is that it works with the Fabric version of [TARDIS Refined](https://modrinth.com/mod/tardis-refined), which also creates dimensions dynamically.

I wrote MarkDirtyMap in Java because it seemed easier considering we are wrapping a regular Java map.