### PR TITLE
Replace the `attributeslib_potion_gui_tooltips` CoreMod with a Mixin.

### DIFF
--- a/compat/forge-compats/build.gradle.kts
+++ b/compat/forge-compats/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     compileOnly("maven.modrinth:ldlib:${property("ldlib_version")}")
     compileOnly("maven.modrinth:littletiles:${property("littletiles_version")}")
     modCompileOnly("maven.modrinth:creativecore:${property("creativecore_version")}")
+    compileOnly("curse.maven:apothic-attributes-898963:${property("apothic_attributes_version")}")
 }
 
 tasks {

--- a/compat/forge-compats/src/main/java/xyz/bluspring/kilt/compat/forge/mixin/attributeslib/EffectRenderingInventoryScreenMixin.java
+++ b/compat/forge-compats/src/main/java/xyz/bluspring/kilt/compat/forge/mixin/attributeslib/EffectRenderingInventoryScreenMixin.java
@@ -1,0 +1,34 @@
+package xyz.bluspring.kilt.compat.forge.mixin.attributeslib;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
+import dev.shadowsoffire.attributeslib.asm.ALHooks;
+import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.effect.MobEffectInstance;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.List;
+
+@IfModLoaded("attributeslib")
+@Mixin(EffectRenderingInventoryScreen.class)
+public abstract class EffectRenderingInventoryScreenMixin {
+
+    // Re-implements the following CoreMod.
+    // https://github.com/Shadows-of-Fire/Apothic-Attributes/blob/1.20/src/main/resources/coremods/potion_gui_tooltips.js
+    @ModifyExpressionValue(
+        method = "renderEffects",
+        at = @At(
+            value = "INVOKE",
+            target = "Ljava/util/List;of(Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/List;"
+        )
+    )
+    private List<Component> kilt$attributeslib$getEffectTooltip(
+        List<Component> original, @Local MobEffectInstance mobEffectInstance
+    ) {
+        return ALHooks.getEffectTooltip((EffectRenderingInventoryScreen<?>) (Object) this, mobEffectInstance, original);
+    }
+
+}

--- a/compat/forge-compats/src/main/kotlin/xyz/bluspring/kilt/compat/forge/CoreModDisabler.kt
+++ b/compat/forge-compats/src/main/kotlin/xyz/bluspring/kilt/compat/forge/CoreModDisabler.kt
@@ -1,0 +1,13 @@
+package xyz.bluspring.kilt.compat.forge
+
+import xyz.bluspring.kilt.event.LoadCoreModEvent
+import xyz.bluspring.kilt.loader.asm.coremod.CoreMod
+
+class CoreModDisabler : LoadCoreModEvent {
+    override fun loadCoreMod(coremod: CoreMod): Boolean {
+        if (coremod.mod.modId == "attributeslib" && coremod.id == "attributeslib_potion_gui_tooltips") {
+            return false
+        }
+        return true
+    }
+}

--- a/compat/forge-compats/src/main/resources/META-INF/services/xyz.bluspring.kilt.event.LoadCoreModEvent
+++ b/compat/forge-compats/src/main/resources/META-INF/services/xyz.bluspring.kilt.event.LoadCoreModEvent
@@ -1,0 +1,1 @@
+xyz.bluspring.kilt.compat.forge.CoreModDisabler

--- a/compat/forge-compats/src/main/resources/kilt_forge_compats.mixins.json
+++ b/compat/forge-compats/src/main/resources/kilt_forge_compats.mixins.json
@@ -12,6 +12,7 @@
         "thirst.PotionItemMixin"
     ],
     "client": [
+        "attributeslib.EffectRenderingInventoryScreenMixin",
         "immersiveengineering.ChunkBuilderMeshingTaskMixin",
         "immersiveengineering.SodiumWorldRendererAccessor",
         "ldlib.BlockRenderDispatcherMixin",

--- a/compat/gradle.properties
+++ b/compat/gradle.properties
@@ -22,3 +22,5 @@ littletiles_version = sBbUjEhq
 creativecore_version = HoxFnPO8
 # https://modrinth.com/mod/lodestonelib
 lodestone_version = 1.20.1-1.6.2.3f
+# https://www.curseforge.com/minecraft/mc-mods/apothic-attributes/files/all?page=1&pageSize=20&version=1.20.1&showAlphaFiles=show
+apothic_attributes_version = 5634071

--- a/src/main/kotlin/xyz/bluspring/kilt/event/LoadCoreModEvent.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/event/LoadCoreModEvent.kt
@@ -1,0 +1,9 @@
+package xyz.bluspring.kilt.event
+
+import xyz.bluspring.kilt.loader.asm.coremod.CoreMod
+
+fun interface LoadCoreModEvent {
+
+    fun loadCoreMod(coremod: CoreMod): Boolean
+
+}

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/coremod/CoreModLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/coremod/CoreModLoader.kt
@@ -2,8 +2,10 @@ package xyz.bluspring.kilt.loader.asm.coremod
 
 import com.google.gson.JsonParser
 import net.fabricmc.loader.impl.gui.FabricGuiEntry
+import xyz.bluspring.kilt.event.LoadCoreModEvent
 import xyz.bluspring.kilt.loader.KiltFlags
 import xyz.bluspring.kilt.loader.mod.ForgeMod
+import java.util.ServiceLoader
 
 
 // A reimplementation of Forge's coremodding system.
@@ -67,6 +69,12 @@ object CoreModLoader {
     val loadedCoreMods = mutableListOf<CoreMod>()
     val enableCoreMods = KiltFlags.DISABLE_COREMODS
 
+    val loadEvent = LoadCoreModEvent {
+        coremod: CoreMod -> ServiceLoader.load(LoadCoreModEvent::class.java).toList().all { event ->
+            event.loadCoreMod(coremod)
+        }
+    }
+
     fun scanAndLoadCoreMods(mod: ForgeMod) {
         if (!enableCoreMods)
             return
@@ -82,6 +90,8 @@ object CoreModLoader {
                 for (key in json.keySet()) {
                     val filePath = json.get(key).asString
                     val coreMod = CoreMod(mod, key, filePath)
+
+                    if (!loadEvent.loadCoreMod(coreMod)) continue
 
                     coreMod.init()
 


### PR DESCRIPTION
Re-implements the following CoreMod as a mixin:
https://github.com/Shadows-of-Fire/Apothic-Attributes/blob/1.20/src/main/resources/coremods/potion_gui_tooltips.js

We need to disable it completely since it breaks the bytecode. I decided to use ServiceLoader for this so we don't have to worry about registering the event too late.