### PR TITLE
Fix forge crafting remainder items not being used.

### DIFF
--- a/src/main/java/xyz/bluspring/kilt/mixin/workarounds/crafting_remainders/FabricItemMixin.java
+++ b/src/main/java/xyz/bluspring/kilt/mixin/workarounds/crafting_remainders/FabricItemMixin.java
@@ -1,0 +1,33 @@
+package xyz.bluspring.kilt.mixin.workarounds.crafting_remainders;
+
+import net.fabricmc.fabric.api.item.v1.FabricItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.extensions.IForgeItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.bluspring.kilt.util.KiltHelper;
+
+@Mixin(FabricItem.class)
+public interface FabricItemMixin {
+
+    @Inject(method = "getRecipeRemainder", at = @At("RETURN"), cancellable = true)
+    private void kilt$getForgeRecipeRemainder(ItemStack stack, CallbackInfoReturnable<ItemStack> cir) {
+        if (
+            KiltHelper.INSTANCE.hasMethodOverride(
+                stack.getItem().getClass(), IForgeItem.class,
+                "hasCraftingRemainingItem", ItemStack.class
+            ) ||
+            KiltHelper.INSTANCE.hasMethodOverride(
+                stack.getItem().getClass(), IForgeItem.class,
+                "getCraftingRemainingItem", ItemStack.class
+            )
+        ) {
+            if (stack.hasCraftingRemainingItem()) {
+                cir.setReturnValue(stack.getCraftingRemainingItem());
+            }
+        }
+    }
+
+}

--- a/src/main/java/xyz/bluspring/kilt/mixin/workarounds/crafting_remainders/IForgeItemMixin.java
+++ b/src/main/java/xyz/bluspring/kilt/mixin/workarounds/crafting_remainders/IForgeItemMixin.java
@@ -1,0 +1,44 @@
+package xyz.bluspring.kilt.mixin.workarounds.crafting_remainders;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.extensions.IForgeItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import xyz.bluspring.kilt.workarounds.IForgeItemCraftingRemainderWorkaround;
+
+@Mixin(IForgeItem.class)
+public interface IForgeItemMixin {
+
+    @Shadow
+    private Item self() {
+        throw new IllegalArgumentException("self() broke");
+    }
+
+    @WrapOperation(
+        method = "getCraftingRemainingItem",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/item/Item;getRecipeRemainder(Lnet/minecraft/world/item/ItemStack;)Lnet/minecraft/world/item/ItemStack;"
+        )
+    )
+    private ItemStack kilt$getCraftingRemainingItem(Item item, ItemStack stack, Operation<ItemStack> original) {
+        if (!IForgeItemCraftingRemainderWorkaround.kilt$isCheckingCraftingItem.get()) {
+            try {
+                IForgeItemCraftingRemainderWorkaround.kilt$isCheckingCraftingItem.set(true);
+                return original.call(item, stack);
+            } finally {
+                IForgeItemCraftingRemainderWorkaround.kilt$isCheckingCraftingItem.set(false);
+            }
+        }
+
+        // Fallback to avoid stack overflow.
+        if (!self().hasCraftingRemainingItem(stack)) {
+            return ItemStack.EMPTY;
+        }
+        return new ItemStack(self().getCraftingRemainingItem());
+    }
+}

--- a/src/main/java/xyz/bluspring/kilt/workarounds/IForgeItemCraftingRemainderWorkaround.java
+++ b/src/main/java/xyz/bluspring/kilt/workarounds/IForgeItemCraftingRemainderWorkaround.java
@@ -1,0 +1,7 @@
+package xyz.bluspring.kilt.workarounds;
+
+public interface IForgeItemCraftingRemainderWorkaround {
+
+    ThreadLocal<Boolean> kilt$isCheckingCraftingItem = ThreadLocal.withInitial(() -> false);
+
+}

--- a/src/main/resources/Kilt.mixins.json
+++ b/src/main/resources/Kilt.mixins.json
@@ -99,6 +99,7 @@
     "server.level.TicketAccessor",
     "workarounds.avoid_feature_cycles.BiomeGenerationSettings$PlainBuilderMixin",
     "workarounds.crafting_remainders.FabricItemMixin",
+    "workarounds.crafting_remainders.IForgeItemMixin",
     "workarounds.finalize_spawn.ForgeEventFactoryMixin$Early",
     "workarounds.finalize_spawn.ForgeEventFactoryMixin$Late",
     "workarounds.fluid_stack_droplets.FluidStackMixin",

--- a/src/main/resources/Kilt.mixins.json
+++ b/src/main/resources/Kilt.mixins.json
@@ -98,6 +98,7 @@
     "resources.RegistryOpsAccessor",
     "server.level.TicketAccessor",
     "workarounds.avoid_feature_cycles.BiomeGenerationSettings$PlainBuilderMixin",
+    "workarounds.crafting_remainders.FabricItemMixin",
     "workarounds.finalize_spawn.ForgeEventFactoryMixin$Early",
     "workarounds.finalize_spawn.ForgeEventFactoryMixin$Late",
     "workarounds.fluid_stack_droplets.FluidStackMixin",


### PR DESCRIPTION
Hooks into Fabric API so `FabricItem::getRecipeRemainder` attempts to use the forge crafting remainder if overridden.

I considered adding manual injects into BannerDuplicateRecipe and BookCloningRecipe as well since Fabric API doesn't handle them, but wasn't sure if any forge mods would actually use them.

 I also added a stack overflow mitigation to the forge module, let me know if you'd like me to move that into a mixin or something.