### PR TITLE
Backport ModifiedCloneWorkaroundLoader to 1.20.1.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -256,7 +256,7 @@ allprojects {
 
             // Cursed Fabric/Mixin stuff
             implementation("com.github.FabricCompatibilityLayers.CursedMixinExtensions:CursedMixinExtensions:${rootProject.property("cursedmixinextensions_version")}")
-            modImplementation("com.github.Chocohead:Fabric-ASM:v${rootProject.property("fabric_asm_version")}")
+            modImplementation("xyz.bluspring.fork:Fabric-ASM:${rootProject.property("fabric_asm_version")}")
             implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${rootProject.property("mixin_squared_version")}")!!)
             modApi("de.florianreuth:asmfabricloader:${property("asmfabricloader_version")}")
         }
@@ -273,7 +273,7 @@ dependencies {
     // JiJ'd into main JAR alone
     include("io.github.llamalad7:mixinextras-fabric:${property("mixinextras_version")}")
     include("com.github.FabricCompatibilityLayers:CursedMixinExtensions:${property("cursedmixinextensions_version")}")
-    include("com.github.Chocohead:Fabric-ASM:v${property("fabric_asm_version")}")
+    include("xyz.bluspring.fork:Fabric-ASM:${property("fabric_asm_version")}")
     include("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${rootProject.property("mixin_squared_version")}")
     include("de.florianreuth:asmfabricloader:${property("asmfabricloader_version")}")
     include("com.moulberry:mixinconstraints:${rootProject.property("mixinconstraints_version")}") {

--- a/compat/create-compat/src/main/kotlin/xyz/bluspring/kilt/compat/create/CompatEarlyRiser.kt
+++ b/compat/create-compat/src/main/kotlin/xyz/bluspring/kilt/compat/create/CompatEarlyRiser.kt
@@ -1,6 +1,6 @@
 package xyz.bluspring.kilt.compat.create
 
-import com.chocohead.mm.api.ClassTinkerers
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import net.fabricmc.loader.api.FabricLoader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,8 +49,8 @@ cursedmixinextensions_version=1.1.0
 # https://github.com/LlamaLad7/MixinExtras/releases
 mixinextras_version=0.5.0
 
-# https://github.com/Chocohead/Fabric-ASM/blob/master/build.gradle#L29
-fabric_asm_version=2.3
+# https://github.com/KiltMC/Fabric-ASM
+fabric_asm_version=2.5.3
 
 # https://github.com/Bawnorton/MixinSquared/releases
 mixin_squared_version=0.3.3

--- a/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/ai/goal/RangedBowAttackGoalInject.java
+++ b/src/main/java/xyz/bluspring/kilt/forgeinjects/world/entity/ai/goal/RangedBowAttackGoalInject.java
@@ -5,7 +5,6 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.goal.RangedBowAttackGoal;
 import net.minecraft.world.entity.monster.Monster;
@@ -16,20 +15,11 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import xyz.bluspring.kilt.helpers.mixin.CreateInitializer;
 import xyz.bluspring.kilt.injections.entity.ProjectileUtilInjection;
 
 @Mixin(RangedBowAttackGoal.class)
 public abstract class RangedBowAttackGoalInject<T extends Monster & RangedAttackMob> extends Goal {
-    // Kilt: ----We don't need to implement the custom constructor stuff----
-    //       (he said, like a fucking liar)
-
-    @CreateInitializer
-    public <M extends Mob & RangedAttackMob> RangedBowAttackGoalInject(M mob, double speedModifier, int attackIntervalMin, float attackRadius) {
-        this((T) mob, speedModifier, attackIntervalMin, attackRadius);
-    }
-
-    public RangedBowAttackGoalInject(T mob, double speedModifier, int attackIntervalMin, float attackRadius) {}
+    // Kilt: We don't need to implement the custom constructor stuff
 
     @Shadow @Final private T mob;
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -51,7 +51,7 @@ import xyz.bluspring.kilt.loader.mod.*
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import xyz.bluspring.kilt.util.DistUtil
 import xyz.bluspring.kilt.util.KiltHelper
-import xyz.bluspring.kilt.util.ModifiedCloneWorkaroundLoader
+import xyz.bluspring.kilt.workarounds.ModifiedCloneWorkaroundLoader
 import xyz.bluspring.kilt.util.buildGraph
 import xyz.bluspring.knit.loader.KnitLoader
 import xyz.bluspring.knit.loader.KnitModLoader

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -51,6 +51,7 @@ import xyz.bluspring.kilt.loader.mod.*
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import xyz.bluspring.kilt.util.DistUtil
 import xyz.bluspring.kilt.util.KiltHelper
+import xyz.bluspring.kilt.util.ModifiedCloneWorkaroundLoader
 import xyz.bluspring.kilt.util.buildGraph
 import xyz.bluspring.knit.loader.KnitLoader
 import xyz.bluspring.knit.loader.KnitModLoader
@@ -570,6 +571,8 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
         environment.computePropertyIfAbsent(IEnvironment.Keys.LAUNCHTARGET.get()) { FabricLoader.getInstance().environmentType.name.lowercase() }
         environment.computePropertyIfAbsent(IEnvironment.Keys.UUID.get()) { FabricLoaderImpl.INSTANCE.gameProvider.arguments.getOrDefault("uuid", "00000000-00000000-00000000-00000000") }
         Environment.build(environment) // Use Kilt's environment
+
+        ModifiedCloneWorkaroundLoader.init() // Run at same time as 1.21.1 for consistency.
 
         // Load all of the Forge access transformers
         AccessTransformerLoader.runTransformers()

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -572,7 +572,7 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
         environment.computePropertyIfAbsent(IEnvironment.Keys.UUID.get()) { FabricLoaderImpl.INSTANCE.gameProvider.arguments.getOrDefault("uuid", "00000000-00000000-00000000-00000000") }
         Environment.build(environment) // Use Kilt's environment
 
-        ModifiedCloneWorkaroundLoader.init() // Run at same time as 1.21.1 for consistency.
+        ModifiedCloneWorkaroundLoader.load() // Run at same time as 1.21.1 for consistency.
 
         // Load all of the Forge access transformers
         AccessTransformerLoader.runTransformers()

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/AccessTransformerLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/AccessTransformerLoader.kt
@@ -1,6 +1,6 @@
 package xyz.bluspring.kilt.loader.asm
 
-import com.chocohead.mm.api.ClassTinkerers
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import net.fabricmc.loader.impl.FabricLoaderImpl
 import net.fabricmc.loader.impl.lib.classtweaker.api.ClassTweaker
 import net.fabricmc.loader.impl.lib.classtweaker.api.visitor.AccessWidenerVisitor

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltEarlyRiser.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltEarlyRiser.kt
@@ -1,6 +1,6 @@
 package xyz.bluspring.kilt.loader.asm
 
-import com.chocohead.mm.api.ClassTinkerers
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import net.fabricmc.loader.api.FabricLoader
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/OverridingMethodWrappers.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/OverridingMethodWrappers.kt
@@ -14,6 +14,7 @@ import xyz.bluspring.kilt.loader.KiltLoader
 import xyz.bluspring.kilt.loader.remap.KiltEnhancedRemapper
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import xyz.bluspring.kilt.loader.remap.fixers.mixin.MixinRemapper
+import xyz.bluspring.kilt.util.AnnotationHelper
 import xyz.bluspring.kilt.util.KiltHelper
 import java.io.ByteArrayOutputStream
 import java.nio.file.*
@@ -202,18 +203,14 @@ object OverridingMethodWrappers {
 
     private fun getClassesIf(paths: Collection<Path>, predicate: Predicate<ClassNode>): ClassResult {
         val classes = mutableSetOf<String>()
-        val mixins = mutableMapOf<String, MutableSet<String>>()
+        val mixins = mutableMapOf<String, Set<String>>()
         paths.forEach { path ->
             for (foundClass in findClasses(path)) {
                 val info = getClassInfo(foundClass)
                 if (info != null && predicate.test(info)) {
                     val mixinAnnotation = Annotations.getInvisible(info, Mixin::class.java)
                     if (mixinAnnotation != null) {
-                        mixins[info.name] = Annotations.getValue<List<Type>?>(mixinAnnotation, "value")?.map { it.internalName }?.toMutableSet() ?: mutableSetOf()
-                        val targets = Annotations.getValue<List<String>?>(mixinAnnotation, "targets")
-                        if (targets != null) {
-                            mixins[info.name]?.addAll(targets)
-                        }
+                        mixins[info.name] = AnnotationHelper.getTargets(mixinAnnotation)
                     } else {
                         classes.add(info.name)
                     }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/OverridingMethodWrappers.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/OverridingMethodWrappers.kt
@@ -1,6 +1,6 @@
 package xyz.bluspring.kilt.loader.asm
 
-import com.chocohead.mm.api.ClassTinkerers
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import kotlinx.coroutines.runBlocking
 import net.fabricmc.loader.api.FabricLoader
 import org.objectweb.asm.*

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/coremod/CoreMod.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/coremod/CoreMod.kt
@@ -1,6 +1,6 @@
 package xyz.bluspring.kilt.loader.asm.coremod
 
-import com.chocohead.mm.api.ClassTinkerers
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import net.minecraftforge.coremod.api.TargetType
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.FieldNode

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
@@ -45,7 +45,7 @@ import xyz.bluspring.kilt.loader.remap.resource.ManifestResourceRemapper
 import xyz.bluspring.kilt.util.CaseInsensitiveStringHashSet
 import xyz.bluspring.kilt.util.ClassNameHashSet
 import xyz.bluspring.kilt.util.KiltHelper
-import xyz.bluspring.kilt.util.ModifiedCloneWorkaroundLoader
+import xyz.bluspring.kilt.workarounds.ModifiedCloneWorkaroundLoader
 import xyz.bluspring.knit.loader.mod.ModDefinition
 import xyz.bluspring.knit.loader.util.*
 import java.io.File

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
@@ -45,6 +45,7 @@ import xyz.bluspring.kilt.loader.remap.resource.ManifestResourceRemapper
 import xyz.bluspring.kilt.util.CaseInsensitiveStringHashSet
 import xyz.bluspring.kilt.util.ClassNameHashSet
 import xyz.bluspring.kilt.util.KiltHelper
+import xyz.bluspring.kilt.util.ModifiedCloneWorkaroundLoader
 import xyz.bluspring.knit.loader.mod.ModDefinition
 import xyz.bluspring.knit.loader.util.*
 import java.io.File
@@ -558,6 +559,7 @@ object KiltRemapper {
                         ConflictingStaticMethodFixer.fixClass(remappedNode)
                         EnvironmentRemapper.remapClass(remappedNode)
                         EnvironmentLambdaFixer.fixClass(remappedNode)
+                        ModifiedCloneWorkaroundLoader.fixClass(remappedNode)
                     }
 
                     val writer = ClassWriter(Opcodes.ASM9)

--- a/src/main/kotlin/xyz/bluspring/kilt/util/AnnotationHelper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/AnnotationHelper.kt
@@ -1,0 +1,18 @@
+package xyz.bluspring.kilt.util
+
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.AnnotationNode
+import org.spongepowered.asm.util.Annotations
+
+object AnnotationHelper {
+
+    fun getTargets(mixinAnnotation: AnnotationNode): Set<String> {
+        val targets = Annotations.getValue<List<Type>?>(mixinAnnotation, "value")?.map { it.internalName }?.toMutableSet() ?: mutableSetOf()
+        val additionalTargets = Annotations.getValue<List<String>?>(mixinAnnotation, "targets")
+        if (additionalTargets != null) {
+            targets.addAll(targets)
+        }
+        return targets
+    }
+
+}

--- a/src/main/kotlin/xyz/bluspring/kilt/util/EnumUtils.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/EnumUtils.kt
@@ -1,7 +1,7 @@
 package xyz.bluspring.kilt.util
 
-import com.chocohead.mm.CasualStreamHandler
-import com.chocohead.mm.api.ClassTinkerers
+import xyz.bluspring.fork.mm.CasualStreamHandler
+import xyz.bluspring.fork.mm.api.ClassTinkerers
 import com.mojang.serialization.Codec
 import net.minecraftforge.common.IExtensibleEnum
 import net.minecraftforge.fml.unsafe.UnsafeHacks

--- a/src/main/kotlin/xyz/bluspring/kilt/util/ModifiedCloneWorkaroundLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/ModifiedCloneWorkaroundLoader.kt
@@ -1,0 +1,305 @@
+package xyz.bluspring.kilt.util
+
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Handle
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.*
+import xyz.bluspring.fork.mm.api.ClassTinkerers
+import xyz.bluspring.kilt.loader.remap.KiltRemapper
+
+object ModifiedCloneWorkaroundLoader {
+
+    fun init() {
+        val monsterType = KiltRemapper.remapClass("net/minecraft/world/entity/monster/Monster")
+        val monsterDesc = "L$monsterType;"
+        val mobType = KiltRemapper.remapClass("net/minecraft/world/entity/Mob")
+        val mobDesc = "L$mobType;"
+        val rangedAttackMob = KiltRemapper.remapDescriptor("Lnet/minecraft/world/entity/monster/RangedAttackMob;")
+        run {
+            val bowAttackGoal = "net/minecraft/world/entity/ai/goal/RangedBowAttackGoal"
+            val bowAttackGoalClone = "xyz/bluspring/kilt/workarounds/RangedBowAttackGoalWorkaround"
+            addTransformedClone(
+                KiltRemapper.remapClass(bowAttackGoal),
+                bowAttackGoalClone,
+            ) { classNode ->
+                replaceType(classNode, monsterType, mobType)
+
+                val fallbackConstructor = MethodNode(
+                    Opcodes.ACC_PUBLIC, "<init>", "(${monsterDesc}DIF)V",
+                    "<M:$monsterDesc:$rangedAttackMob>(TM;DIF)V", null
+                ).apply {
+                    val startLabel = LabelNode()
+                    this.instructions.add(startLabel)
+                    this.instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+                    this.instructions.add(VarInsnNode(Opcodes.ALOAD, 1))
+                    this.instructions.add(VarInsnNode(Opcodes.DLOAD, 2)) // Fun fact, double parameters take 2 variable slots.
+                    this.instructions.add(VarInsnNode(Opcodes.ILOAD, 4))
+                    this.instructions.add(VarInsnNode(Opcodes.FLOAD, 5))
+                    this.instructions.add(
+                        MethodInsnNode(
+                            Opcodes.INVOKESPECIAL, bowAttackGoalClone,
+                            "<init>", "(${mobDesc}DIF)V"
+                        )
+                    )
+                    this.instructions.add(LabelNode())
+                    this.instructions.add(InsnNode(Opcodes.RETURN))
+                    val endLabel = LabelNode()
+                    this.instructions.add(endLabel)
+
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "this", "L$bowAttackGoalClone;", "L$bowAttackGoalClone<TT;>;",
+                            startLabel, endLabel, 0
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "mob", monsterDesc, "TM;",
+                            startLabel, endLabel, 1
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "speedModifier", "D", null,
+                            startLabel, endLabel, 2
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "attackIntervalMin", "I", null,
+                            startLabel, endLabel, 4
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "attackRadius", "F", null,
+                            startLabel, endLabel, 5
+                        )
+                    )
+                }
+                classNode.methods.add(fallbackConstructor)
+            }
+        }
+
+        run {
+            val crossbowAttackGoal = "net/minecraft/world/entity/ai/goal/RangedCrossbowAttackGoal"
+            val crossbowAttackGoalClone = "xyz/bluspring/kilt/workarounds/RangedCrossbowAttackGoalWorkaround"
+            addTransformedClone(
+                KiltRemapper.remapClass(crossbowAttackGoal),
+                crossbowAttackGoalClone,
+            ) { classNode ->
+                replaceType(classNode, monsterType, mobType)
+
+                val fallbackConstructor = MethodNode(
+                    Opcodes.ACC_PUBLIC, "<init>", "(${monsterDesc}DF)V",
+                    "<M:$monsterDesc:$rangedAttackMob:${KiltRemapper.remapDescriptor("Lnet/minecraft/world/entity/monster/CrossbowAttackMob;")}>(TM;DF)V", null
+                ).apply {
+                    val startLabel = LabelNode()
+                    this.instructions.add(startLabel)
+                    this.instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+                    this.instructions.add(VarInsnNode(Opcodes.ALOAD, 1))
+                    this.instructions.add(VarInsnNode(Opcodes.DLOAD, 2)) // Fun fact, double parameters take 2 variable slots.
+                    this.instructions.add(VarInsnNode(Opcodes.FLOAD, 4))
+                    this.instructions.add(
+                        MethodInsnNode(
+                            Opcodes.INVOKESPECIAL, crossbowAttackGoalClone,
+                            "<init>", "(${mobDesc}DF)V"
+                        )
+                    )
+                    this.instructions.add(LabelNode())
+                    this.instructions.add(InsnNode(Opcodes.RETURN))
+                    val endLabel = LabelNode()
+                    this.instructions.add(endLabel)
+
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "this", "L$crossbowAttackGoalClone;", "L$crossbowAttackGoalClone<TT;>;",
+                            startLabel, endLabel, 0
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "mob", monsterDesc, "TM;",
+                            startLabel, endLabel, 1
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "speedModifier", "D", null,
+                            startLabel, endLabel, 2
+                        )
+                    )
+                    this.localVariables.add(
+                        LocalVariableNode(
+                            "attackRadius", "F", null,
+                            startLabel, endLabel, 4
+                        )
+                    )
+                }
+                classNode.methods.add(fallbackConstructor)
+            }
+        }
+    }
+
+    private fun mapType(type: Type, oldTypeName: String, newTypeDesc: String): Type {
+        when (type.sort) {
+            Type.OBJECT -> {
+                if (type.internalName == oldTypeName) {
+                    return Type.getType(newTypeDesc)
+                }
+            }
+            Type.ARRAY -> {
+                val dimensions = type.dimensions
+                val elementType = type.elementType
+                if (elementType.internalName == oldTypeName) {
+                    return Type.getType("[".repeat(dimensions) + newTypeDesc)
+                }
+            }
+        }
+        return type
+    }
+
+    private fun mapHandle(handle: Handle, oldTypeName: String, newTypeName: String): Handle {
+        if (handle.owner == oldTypeName) {
+            return Handle(
+                handle.tag, newTypeName, handle.name, handle.desc, handle.isInterface
+            )
+        }
+        return handle
+    }
+
+    private fun mapFrameTypes(frameTypes: List<Any?>?, oldOwnerName: String, newOwnerName: String): List<Any?>? {
+        if (frameTypes == null) return frameTypes
+        var newTypes: MutableList<Any?>? = null
+        for (i in frameTypes.indices) {
+            val type = frameTypes[i]
+            if (type is String && type == oldOwnerName) {
+                if (newTypes == null) {
+                    newTypes = frameTypes.toMutableList()
+                }
+                newTypes[i] = newOwnerName
+            }
+        }
+        return newTypes ?: frameTypes
+    }
+
+    private fun setClassName(node: ClassNode, oldOwnerName: String, newOwnerName: String) {
+        val oldOwnerDesc = "L$oldOwnerName;"
+        val newOwnerDesc = "L$newOwnerName;"
+        node.name = newOwnerName
+        for (method in node.methods) {
+            for (insn in method.instructions) {
+                when (insn) {
+                    is FieldInsnNode -> if (insn.owner == oldOwnerName) insn.owner = newOwnerName
+                    is MethodInsnNode -> if (insn.owner == oldOwnerName) insn.owner = newOwnerName
+                    is LdcInsnNode -> {
+                        val type = insn.cst
+                        if (type is Type) {
+                            insn.cst = mapType(type, oldOwnerName, newOwnerDesc)
+                        }
+                    }
+                    is TypeInsnNode -> if (insn.desc == oldOwnerName) insn.desc = newOwnerName
+                    is InvokeDynamicInsnNode -> {
+                        for (i in insn.bsmArgs.indices) {
+                            val arg = insn.bsmArgs[i]
+                            when (arg) {
+                                is Type -> insn.bsmArgs[i] = mapType(arg, oldOwnerName, newOwnerDesc)
+                                is Handle -> insn.bsmArgs[i] = mapHandle(arg, oldOwnerName, newOwnerName)
+                            }
+                        }
+                    }
+                    is FrameNode -> {
+                        insn.local = mapFrameTypes(insn.local, oldOwnerName, newOwnerName)
+                        insn.stack = mapFrameTypes(insn.stack, oldOwnerName, newOwnerName)
+                    }
+                }
+            }
+            for (local in method.localVariables) {
+                if (local.desc == oldOwnerDesc) {
+                    local.desc = newOwnerDesc
+                }
+                local.signature = local.signature?.replace(oldOwnerName, newOwnerName)
+            }
+            method.signature = method.signature?.replace(oldOwnerName, newOwnerName)
+        }
+        for (field in node.fields) {
+            field.signature = field.signature?.replace(oldOwnerName, newOwnerName)
+        }
+    }
+
+    fun addTransformedClone(
+        targetClass: String, cloneClass: String,
+        transformer: (ClassNode) -> Unit
+    ) {
+        var originalNode: ClassNode? = null
+        ClassTinkerers.addPostTransformation(targetClass) { classNode ->
+            originalNode = classNode
+        }
+        val cw = ClassWriter(0)
+        cw.visit(
+            52,
+            Opcodes.ACC_PUBLIC,
+            cloneClass,
+            null,
+            "java/lang/Object",
+            null
+        )
+        ClassTinkerers.define(cloneClass, cw.toByteArray())
+        ClassTinkerers.addPostTransformation(cloneClass) { classNode ->
+            Class.forName(targetClass.replace("/", ".")) // Classload it somehow so the transform always runs first
+            originalNode?.accept(classNode)
+
+            setClassName(classNode, targetClass, cloneClass)
+
+            transformer(classNode)
+        }
+    }
+
+    fun replaceType(
+        classNode: ClassNode,
+        oldType: String,
+        newType: String
+    ) {
+        val oldDescriptor = "L$oldType;"
+        val newDescriptor = "L$newType;"
+        classNode.signature = classNode.signature?.replace(oldDescriptor, newDescriptor)
+
+        for (field in classNode.fields) {
+            if (field.desc == oldDescriptor) {
+                field.desc = newDescriptor
+            }
+            field.signature = field.signature?.replace(oldDescriptor, newDescriptor)
+        }
+
+        for (method in classNode.methods) {
+            method.desc = method.desc.replace(oldDescriptor, newDescriptor)
+            method.signature = method.signature?.replace(oldDescriptor, newDescriptor)
+        }
+
+        for (method in classNode.methods) {
+            for (insn in method.instructions) {
+                when (insn) {
+                    is FieldInsnNode -> {
+                        if (insn.owner == oldType) {
+                            insn.owner = newType
+                        }
+                        insn.desc = insn.desc.replace(oldDescriptor, newDescriptor)
+                    }
+                    is MethodInsnNode -> {
+                        if (insn.owner == oldType) {
+                            insn.owner = newType
+                        }
+                        insn.desc = insn.desc.replace(oldDescriptor, newDescriptor)
+                    }
+                }
+            }
+            for (local in method.localVariables) {
+                if (local.desc == oldDescriptor) {
+                    local.desc = newDescriptor
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/xyz/bluspring/kilt/util/ModifiedCloneWorkaroundLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/util/ModifiedCloneWorkaroundLoader.kt
@@ -10,7 +10,10 @@ import xyz.bluspring.kilt.loader.remap.KiltRemapper
 
 object ModifiedCloneWorkaroundLoader {
 
-    fun init() {
+    val REMAPPED_TYPES = mutableMapOf<String, String>()
+    val TRANSFORMERS = mutableListOf<() -> Unit>()
+
+    init {
         val monsterType = KiltRemapper.remapClass("net/minecraft/world/entity/monster/Monster")
         val monsterDesc = "L$monsterType;"
         val mobType = KiltRemapper.remapClass("net/minecraft/world/entity/Mob")
@@ -142,6 +145,11 @@ object ModifiedCloneWorkaroundLoader {
         }
     }
 
+    fun load() {
+        TRANSFORMERS.forEach { it() }
+        TRANSFORMERS.clear()
+    }
+
     private fun mapType(type: Type, oldTypeName: String, newTypeDesc: String): Type {
         when (type.sort) {
             Type.OBJECT -> {
@@ -185,74 +193,38 @@ object ModifiedCloneWorkaroundLoader {
     }
 
     private fun setClassName(node: ClassNode, oldOwnerName: String, newOwnerName: String) {
-        val oldOwnerDesc = "L$oldOwnerName;"
-        val newOwnerDesc = "L$newOwnerName;"
         node.name = newOwnerName
-        for (method in node.methods) {
-            for (insn in method.instructions) {
-                when (insn) {
-                    is FieldInsnNode -> if (insn.owner == oldOwnerName) insn.owner = newOwnerName
-                    is MethodInsnNode -> if (insn.owner == oldOwnerName) insn.owner = newOwnerName
-                    is LdcInsnNode -> {
-                        val type = insn.cst
-                        if (type is Type) {
-                            insn.cst = mapType(type, oldOwnerName, newOwnerDesc)
-                        }
-                    }
-                    is TypeInsnNode -> if (insn.desc == oldOwnerName) insn.desc = newOwnerName
-                    is InvokeDynamicInsnNode -> {
-                        for (i in insn.bsmArgs.indices) {
-                            val arg = insn.bsmArgs[i]
-                            when (arg) {
-                                is Type -> insn.bsmArgs[i] = mapType(arg, oldOwnerName, newOwnerDesc)
-                                is Handle -> insn.bsmArgs[i] = mapHandle(arg, oldOwnerName, newOwnerName)
-                            }
-                        }
-                    }
-                    is FrameNode -> {
-                        insn.local = mapFrameTypes(insn.local, oldOwnerName, newOwnerName)
-                        insn.stack = mapFrameTypes(insn.stack, oldOwnerName, newOwnerName)
-                    }
-                }
-            }
-            for (local in method.localVariables) {
-                if (local.desc == oldOwnerDesc) {
-                    local.desc = newOwnerDesc
-                }
-                local.signature = local.signature?.replace(oldOwnerName, newOwnerName)
-            }
-            method.signature = method.signature?.replace(oldOwnerName, newOwnerName)
-        }
-        for (field in node.fields) {
-            field.signature = field.signature?.replace(oldOwnerName, newOwnerName)
-        }
+        replaceType(node, oldOwnerName, newOwnerName)
     }
 
     fun addTransformedClone(
         targetClass: String, cloneClass: String,
         transformer: (ClassNode) -> Unit
     ) {
-        var originalNode: ClassNode? = null
-        ClassTinkerers.addPostTransformation(targetClass) { classNode ->
-            originalNode = classNode
-        }
-        val cw = ClassWriter(0)
-        cw.visit(
-            52,
-            Opcodes.ACC_PUBLIC,
-            cloneClass,
-            null,
-            "java/lang/Object",
-            null
-        )
-        ClassTinkerers.define(cloneClass, cw.toByteArray())
-        ClassTinkerers.addPostTransformation(cloneClass) { classNode ->
-            Class.forName(targetClass.replace("/", ".")) // Classload it somehow so the transform always runs first
-            originalNode?.accept(classNode)
+        REMAPPED_TYPES[targetClass] = cloneClass
+        TRANSFORMERS.add {
+            var originalNode: ClassNode? = null
+            ClassTinkerers.addPostTransformation(targetClass) { classNode ->
+                originalNode = classNode
+            }
+            val cw = ClassWriter(0)
+            cw.visit(
+                52,
+                Opcodes.ACC_PUBLIC,
+                cloneClass,
+                null,
+                "java/lang/Object",
+                null
+            )
+            ClassTinkerers.define(cloneClass, cw.toByteArray())
+            ClassTinkerers.addPostTransformation(cloneClass) { classNode ->
+                Class.forName(targetClass.replace("/", ".")) // Classload it somehow so the transform always runs first
+                originalNode?.accept(classNode)
 
-            setClassName(classNode, targetClass, cloneClass)
+                setClassName(classNode, targetClass, cloneClass)
 
-            transformer(classNode)
+                transformer(classNode)
+            }
         }
     }
 
@@ -264,6 +236,16 @@ object ModifiedCloneWorkaroundLoader {
         val oldDescriptor = "L$oldType;"
         val newDescriptor = "L$newType;"
         classNode.signature = classNode.signature?.replace(oldDescriptor, newDescriptor)
+        if (classNode.superName == oldType) {
+            classNode.superName = newType
+        }
+
+        classNode.interfaces = classNode.interfaces.map {
+            if (it == oldType) {
+                return@map newType
+            }
+            return@map it
+        }
 
         for (field in classNode.fields) {
             if (field.desc == oldDescriptor) {
@@ -292,14 +274,44 @@ object ModifiedCloneWorkaroundLoader {
                         }
                         insn.desc = insn.desc.replace(oldDescriptor, newDescriptor)
                     }
+                    is LdcInsnNode -> {
+                        val type = insn.cst
+                        if (type is Type) {
+                            insn.cst = mapType(type, oldType, newDescriptor)
+                        }
+                    }
+                    is TypeInsnNode -> if (insn.desc == oldType) insn.desc = newType
+                    is InvokeDynamicInsnNode -> {
+                        for (i in insn.bsmArgs.indices) {
+                            val arg = insn.bsmArgs[i]
+                            when (arg) {
+                                is Type -> insn.bsmArgs[i] = mapType(arg, oldType, newDescriptor)
+                                is Handle -> insn.bsmArgs[i] = mapHandle(arg, oldType, newType)
+                            }
+                        }
+                    }
+                    is FrameNode -> {
+                        insn.local = mapFrameTypes(insn.local, oldType, newDescriptor)
+                        insn.stack = mapFrameTypes(insn.stack, oldType, newDescriptor)
+                    }
                 }
             }
-            for (local in method.localVariables) {
-                if (local.desc == oldDescriptor) {
-                    local.desc = newDescriptor
+            if (method.localVariables != null) {
+                for (local in method.localVariables) {
+                    if (local.desc == oldDescriptor) {
+                        local.desc = newDescriptor
+                    }
+                    local.signature = local.signature?.replace(oldType, newType)
                 }
             }
+            method.signature = method.signature?.replace(oldType, newType)
         }
+
     }
 
+    fun fixClass(classNode: ClassNode) {
+        for ((from, to) in REMAPPED_TYPES) {
+            replaceType(classNode, from, to)
+        }
+    }
 }

--- a/src/main/kotlin/xyz/bluspring/kilt/workarounds/ModifiedCloneWorkaroundLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/workarounds/ModifiedCloneWorkaroundLoader.kt
@@ -1,17 +1,29 @@
-package xyz.bluspring.kilt.util
+package xyz.bluspring.kilt.workarounds
 
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Handle
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
-import org.objectweb.asm.tree.*
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.FieldInsnNode
+import org.objectweb.asm.tree.FrameNode
+import org.objectweb.asm.tree.InsnNode
+import org.objectweb.asm.tree.InvokeDynamicInsnNode
+import org.objectweb.asm.tree.LabelNode
+import org.objectweb.asm.tree.LdcInsnNode
+import org.objectweb.asm.tree.LocalVariableNode
+import org.objectweb.asm.tree.MethodInsnNode
+import org.objectweb.asm.tree.MethodNode
+import org.objectweb.asm.tree.TypeInsnNode
+import org.objectweb.asm.tree.VarInsnNode
 import xyz.bluspring.fork.mm.api.ClassTinkerers
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
+import kotlin.collections.iterator
 
 object ModifiedCloneWorkaroundLoader {
 
     val REMAPPED_TYPES = mutableMapOf<String, String>()
-    val TRANSFORMERS = mutableListOf<() -> Unit>()
+    val TRANSFORMERS = mutableListOf<Runnable>()
 
     init {
         val monsterType = KiltRemapper.remapClass("net/minecraft/world/entity/monster/Monster")
@@ -29,9 +41,9 @@ object ModifiedCloneWorkaroundLoader {
                 replaceType(classNode, monsterType, mobType)
 
                 val fallbackConstructor = MethodNode(
-                    Opcodes.ACC_PUBLIC, "<init>", "(${monsterDesc}DIF)V",
-                    "<M:$monsterDesc:$rangedAttackMob>(TM;DIF)V", null
-                ).apply {
+					Opcodes.ACC_PUBLIC, "<init>", "(${monsterDesc}DIF)V",
+					"<M:$monsterDesc:$rangedAttackMob>(TM;DIF)V", null
+				).apply {
                     val startLabel = LabelNode()
                     this.instructions.add(startLabel)
                     this.instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
@@ -39,47 +51,20 @@ object ModifiedCloneWorkaroundLoader {
                     this.instructions.add(VarInsnNode(Opcodes.DLOAD, 2)) // Fun fact, double parameters take 2 variable slots.
                     this.instructions.add(VarInsnNode(Opcodes.ILOAD, 4))
                     this.instructions.add(VarInsnNode(Opcodes.FLOAD, 5))
-                    this.instructions.add(
-                        MethodInsnNode(
-                            Opcodes.INVOKESPECIAL, bowAttackGoalClone,
-                            "<init>", "(${mobDesc}DIF)V"
-                        )
-                    )
+                    this.instructions.add(MethodInsnNode(
+                        Opcodes.INVOKESPECIAL, bowAttackGoalClone,
+                        "<init>", "(${mobDesc}DIF)V"
+                    ))
                     this.instructions.add(LabelNode())
                     this.instructions.add(InsnNode(Opcodes.RETURN))
                     val endLabel = LabelNode()
                     this.instructions.add(endLabel)
 
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "this", "L$bowAttackGoalClone;", "L$bowAttackGoalClone<TT;>;",
-                            startLabel, endLabel, 0
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "mob", monsterDesc, "TM;",
-                            startLabel, endLabel, 1
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "speedModifier", "D", null,
-                            startLabel, endLabel, 2
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "attackIntervalMin", "I", null,
-                            startLabel, endLabel, 4
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "attackRadius", "F", null,
-                            startLabel, endLabel, 5
-                        )
-                    )
+                    this.localVariables.add(LocalVariableNode("this", "L$bowAttackGoalClone;", "L$bowAttackGoalClone<TT;>;", startLabel, endLabel, 0))
+                    this.localVariables.add(LocalVariableNode("mob", monsterDesc, "TM;", startLabel, endLabel, 1))
+                    this.localVariables.add(LocalVariableNode("speedModifier", "D", null, startLabel, endLabel, 2))
+                    this.localVariables.add(LocalVariableNode("attackIntervalMin", "I", null, startLabel, endLabel, 4))
+                    this.localVariables.add(LocalVariableNode("attackRadius", "F", null, startLabel, endLabel, 5))
                 }
                 classNode.methods.add(fallbackConstructor)
             }
@@ -95,50 +80,31 @@ object ModifiedCloneWorkaroundLoader {
                 replaceType(classNode, monsterType, mobType)
 
                 val fallbackConstructor = MethodNode(
-                    Opcodes.ACC_PUBLIC, "<init>", "(${monsterDesc}DF)V",
-                    "<M:$monsterDesc:$rangedAttackMob:${KiltRemapper.remapDescriptor("Lnet/minecraft/world/entity/monster/CrossbowAttackMob;")}>(TM;DF)V", null
-                ).apply {
+					Opcodes.ACC_PUBLIC,
+	                "<init>",
+	                "(${monsterDesc}DF)V",
+					"<M:$monsterDesc:$rangedAttackMob:${KiltRemapper.remapDescriptor("Lnet/minecraft/world/entity/monster/CrossbowAttackMob;")}>(TM;DF)V",
+	                null
+				).apply {
                     val startLabel = LabelNode()
                     this.instructions.add(startLabel)
                     this.instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
                     this.instructions.add(VarInsnNode(Opcodes.ALOAD, 1))
                     this.instructions.add(VarInsnNode(Opcodes.DLOAD, 2)) // Fun fact, double parameters take 2 variable slots.
                     this.instructions.add(VarInsnNode(Opcodes.FLOAD, 4))
-                    this.instructions.add(
-                        MethodInsnNode(
-                            Opcodes.INVOKESPECIAL, crossbowAttackGoalClone,
-                            "<init>", "(${mobDesc}DF)V"
-                        )
-                    )
+                    this.instructions.add(MethodInsnNode(
+                        Opcodes.INVOKESPECIAL, crossbowAttackGoalClone,
+                        "<init>", "(${mobDesc}DF)V"
+                    ))
                     this.instructions.add(LabelNode())
                     this.instructions.add(InsnNode(Opcodes.RETURN))
                     val endLabel = LabelNode()
                     this.instructions.add(endLabel)
 
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "this", "L$crossbowAttackGoalClone;", "L$crossbowAttackGoalClone<TT;>;",
-                            startLabel, endLabel, 0
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "mob", monsterDesc, "TM;",
-                            startLabel, endLabel, 1
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "speedModifier", "D", null,
-                            startLabel, endLabel, 2
-                        )
-                    )
-                    this.localVariables.add(
-                        LocalVariableNode(
-                            "attackRadius", "F", null,
-                            startLabel, endLabel, 4
-                        )
-                    )
+                    this.localVariables.add(LocalVariableNode("this", "L$crossbowAttackGoalClone;", "L$crossbowAttackGoalClone<TT;>;", startLabel, endLabel, 0))
+                    this.localVariables.add(LocalVariableNode("mob", monsterDesc, "TM;", startLabel, endLabel, 1))
+                    this.localVariables.add(LocalVariableNode("speedModifier", "D", null, startLabel, endLabel, 2))
+                    this.localVariables.add(LocalVariableNode("attackRadius", "F", null, startLabel, endLabel, 4))
                 }
                 classNode.methods.add(fallbackConstructor)
             }
@@ -146,7 +112,7 @@ object ModifiedCloneWorkaroundLoader {
     }
 
     fun load() {
-        TRANSFORMERS.forEach { it() }
+        TRANSFORMERS.forEach(Runnable::run)
         TRANSFORMERS.clear()
     }
 
@@ -170,9 +136,7 @@ object ModifiedCloneWorkaroundLoader {
 
     private fun mapHandle(handle: Handle, oldTypeName: String, newTypeName: String): Handle {
         if (handle.owner == oldTypeName) {
-            return Handle(
-                handle.tag, newTypeName, handle.name, handle.desc, handle.isInterface
-            )
+            return Handle(handle.tag, newTypeName, handle.name, handle.desc, handle.isInterface)
         }
         return handle
     }
@@ -207,16 +171,14 @@ object ModifiedCloneWorkaroundLoader {
             ClassTinkerers.addPostTransformation(targetClass) { classNode ->
                 originalNode = classNode
             }
+
+            // Create an empty class so we don't get ClassNotFoundException when classloading.
+            // Only the class name actually matters, they will all be overwritten during classloading.
+            // 52 is the class version used by Java 8: https://docs.oracle.com/javase/specs/jvms/se26/html/jvms-1.html#jvms-1.2-220
             val cw = ClassWriter(0)
-            cw.visit(
-                52,
-                Opcodes.ACC_PUBLIC,
-                cloneClass,
-                null,
-                "java/lang/Object",
-                null
-            )
+            cw.visit(52, Opcodes.ACC_PUBLIC, cloneClass, null, "java/lang/Object", null)
             ClassTinkerers.define(cloneClass, cw.toByteArray())
+
             ClassTinkerers.addPostTransformation(cloneClass) { classNode ->
                 Class.forName(targetClass.replace("/", ".")) // Classload it somehow so the transform always runs first
                 originalNode?.accept(classNode)
@@ -229,9 +191,9 @@ object ModifiedCloneWorkaroundLoader {
     }
 
     fun replaceType(
-        classNode: ClassNode,
-        oldType: String,
-        newType: String
+		classNode: ClassNode,
+	    oldType: String,
+	    newType: String
     ) {
         val oldDescriptor = "L$oldType;"
         val newDescriptor = "L$newType;"

--- a/src/main/kotlin/xyz/bluspring/kilt/workarounds/ModifiedCloneWorkaroundLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/workarounds/ModifiedCloneWorkaroundLoader.kt
@@ -4,21 +4,12 @@ import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Handle
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
-import org.objectweb.asm.tree.ClassNode
-import org.objectweb.asm.tree.FieldInsnNode
-import org.objectweb.asm.tree.FrameNode
-import org.objectweb.asm.tree.InsnNode
-import org.objectweb.asm.tree.InvokeDynamicInsnNode
-import org.objectweb.asm.tree.LabelNode
-import org.objectweb.asm.tree.LdcInsnNode
-import org.objectweb.asm.tree.LocalVariableNode
-import org.objectweb.asm.tree.MethodInsnNode
-import org.objectweb.asm.tree.MethodNode
-import org.objectweb.asm.tree.TypeInsnNode
-import org.objectweb.asm.tree.VarInsnNode
+import org.objectweb.asm.tree.*
+import org.spongepowered.asm.mixin.Mixin
+import org.spongepowered.asm.util.Annotations
 import xyz.bluspring.fork.mm.api.ClassTinkerers
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
-import kotlin.collections.iterator
+import xyz.bluspring.kilt.util.AnnotationHelper
 
 object ModifiedCloneWorkaroundLoader {
 
@@ -190,6 +181,15 @@ object ModifiedCloneWorkaroundLoader {
         }
     }
 
+    fun isVanillaMixin(classNode: ClassNode): Boolean {
+        val mixinAnnotation = Annotations.getInvisible(classNode, Mixin::class.java)
+        return if (mixinAnnotation != null) {
+            AnnotationHelper.getTargets(mixinAnnotation).any { it.startsWith("net/minecraft") || it.startsWith("com/mojang") }
+        } else {
+            false
+        }
+    }
+
     fun replaceType(
 		classNode: ClassNode,
 	    oldType: String,
@@ -272,6 +272,7 @@ object ModifiedCloneWorkaroundLoader {
     }
 
     fun fixClass(classNode: ClassNode) {
+        if (isVanillaMixin(classNode)) return
         for ((from, to) in REMAPPED_TYPES) {
             replaceType(classNode, from, to)
         }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
     "server": [
       "xyz.bluspring.kilt.server.dedicated.KiltDedicatedServer"
     ],
-    "mm:early_risers": [
+    "mm_kilt:early_risers": [
       "xyz.bluspring.kilt.loader.asm.KiltEarlyRiser"
     ],
     "mixinsquared-adjuster": [
@@ -50,7 +50,7 @@
     "fabric-api": ">=${fabric_version}",
     "minecraft": "${minecraft_version}",
     "fabric-language-kotlin": ">=${fabric_kotlin_version}",
-    "mm": ">=${fabric_asm_version}"
+    "mm_kilt": ">=${fabric_asm_version}"
   },
   "custom": {
     "loom:injected_interfaces": {


### PR DESCRIPTION
Backports #833 to 1.20.1.

Also makes Kilt 1.20.1 use the Kilt fork of Fabric ASM. If we need to revert the Fabric ASM change we'll need to remove ModifiedCloneWorkaroundLoader anyway. I also added some extra checks to ModifiedCloneWorkaroundLoader in order to skip remapping mixins into vanilla classes since that would break things.