### PR TITLE
Backport shadow remapper fixes for parent shadows and signature handling to 1.20.1.

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/KiltRemapper.kt
@@ -524,18 +524,34 @@ object KiltRemapper {
                 }
             }
 
+            fun isMixinClass(node: ClassNode): Boolean {
+                return node.name in mixinClasses ||
+                    // GUESS WHAT, SOME MODS DON'T FUCKING DEFINE SOME MIXINS IN THE FILE, INSTEAD IN THE MIXIN PLUGIN.
+                    // SO LET'S JUST RUN THIS ON EVERYTHING THAT HAS THE BLOODY ANNOTATION.
+                    KiltHelper.mergeNullableCollections(node.visibleAnnotations, node.invisibleAnnotations)
+                        .any { it.desc == MixinAdditionalRemapper.MIXIN_TYPE.descriptor }
+            }
+
+            // Make copies of the original ClassNode objects so we can use them as reference to remap inherited shadows.
+            val originalMappings = mutableMapOf<String, ClassNode>()
+            for (node in entryToClassNodes.values) {
+                if (isMixinClass(node)) {
+                    val writer = ClassWriter(0)
+                    node.accept(writer)
+                    val nodeCopy = ClassReader(writer.toByteArray())
+                    val newNode = ClassNode()
+                    nodeCopy.accept(newNode, 0)
+                    originalMappings[node.name] = newNode
+                }
+            }
+
             val throwable = entryToClassNodes.entries.asFlow().concurrent().runCatching {
                 this.collect { (entry, originalNode) ->
                     // only do this on mixin classes, please
                     // We must remap the mixins before actually remapping them to Intermediary, so the names are correct in prod.
-                    if (originalNode.name in mixinClasses ||
-                        // GUESS WHAT, SOME MODS DON'T FUCKING DEFINE SOME MIXINS IN THE FILE, INSTEAD IN THE MIXIN PLUGIN.
-                        // SO LET'S JUST RUN THIS ON EVERYTHING THAT HAS THE BLOODY ANNOTATION.
-                        KiltHelper.mergeNullableCollections(originalNode.visibleAnnotations, originalNode.invisibleAnnotations)
-                            .any { it.desc == MixinAdditionalRemapper.MIXIN_TYPE.descriptor }
-                    ) {
+                    if (isMixinClass(originalNode)) {
                         MixinRemapper.remapClass(originalNode, enhancedSrgRemapper, mixinRefmaps.values)
-                        MixinShadowRemapper.remapClass(originalNode, enhancedSrgRemapper)
+                        MixinShadowRemapper.remapClass(originalNode, enhancedSrgRemapper, originalMappings)
 
                         if (!KiltFlags.DISABLE_FIXERS) {
                             MixinAdditionalRemapper.remapClass(originalNode)

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinShadowRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinShadowRemapper.kt
@@ -76,10 +76,12 @@ object MixinShadowRemapper {
         return remapped
     }
 
+    data class MethodReference(val name: String, val desc: String)
+
     private fun updateFieldsAndMethods(
         classNode: ClassNode, remapper: KiltEnhancedRemapper,
         remappedFields: MutableMap<String, String>,
-        remappedMethods: MutableMap<String, String>,
+        remappedMethods: MutableMap<MethodReference, String>,
         targetClassNames: Collection<String>,
         unmappedParentMixinLookup: Map<String, ClassNode>, renameNodes: Boolean,
     ) {
@@ -96,7 +98,7 @@ object MixinShadowRemapper {
         for (method in classNode.methods) {
             val remapped = remapMethod(method, remapper, targetClassNames) ?: continue
 
-            remappedMethods[method.name] = remapped
+            remappedMethods[MethodReference(method.name, method.desc)] = remapped
             if (renameNodes) {
                 method.name = remapped
             }
@@ -121,7 +123,7 @@ object MixinShadowRemapper {
 
     fun remapClass(classNode: ClassNode, remapper: KiltEnhancedRemapper, unmappedParentMixinLookup: Map<String, ClassNode>) {
         val remappedFields = mutableMapOf<String, String>()
-        val remappedMethods = mutableMapOf<String, String>()
+        val remappedMethods = mutableMapOf<MethodReference, String>()
         val targetClassNames = MixinRemapper.getMixinClassTargets(classNode)
 
         // Collect shadows in this class
@@ -134,7 +136,7 @@ object MixinShadowRemapper {
                     val remapped = remappedFields[insnNode.name] ?: continue
                     insnNode.name = remapped
                 } else if (insnNode is MethodInsnNode) {
-                    val remapped = remappedMethods[insnNode.name] ?: continue
+                    val remapped = remappedMethods[MethodReference(insnNode.name, insnNode.desc)] ?: continue
                     insnNode.name = remapped
                 } else if (insnNode is InvokeDynamicInsnNode) {
                     if ("metafactory" != insnNode.bsm.name)
@@ -151,7 +153,7 @@ object MixinShadowRemapper {
                             val lambdaTarget = insnNode.bsmArgs[1] as Handle
                             if (lambdaTarget.owner == classNode.name) {
                                 val handle = Handle(lambdaTarget.tag, lambdaTarget.owner,
-                                    remappedMethods[lambdaTarget.name] ?: continue,
+                                    remappedMethods[MethodReference(lambdaTarget.name, lambdaTarget.desc)] ?: continue,
                                     lambdaTarget.desc, lambdaTarget.isInterface
                                 )
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinShadowRemapper.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/remap/fixers/mixin/MixinShadowRemapper.kt
@@ -4,8 +4,10 @@ import org.objectweb.asm.Handle
 import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.FieldInsnNode
+import org.objectweb.asm.tree.FieldNode
 import org.objectweb.asm.tree.InvokeDynamicInsnNode
 import org.objectweb.asm.tree.MethodInsnNode
+import org.objectweb.asm.tree.MethodNode
 import xyz.bluspring.kilt.loader.remap.KiltEnhancedRemapper
 import xyz.bluspring.kilt.loader.remap.KiltRemapper
 import xyz.bluspring.kilt.loader.remap.fixers.EnvironmentLambdaFixer.LAMBDA_CLASS_NAME
@@ -21,19 +23,13 @@ object MixinShadowRemapper {
         "f_92571_" to $$"kilt$blockColors"
     )
 
-    fun remapClass(classNode: ClassNode, remapper: KiltEnhancedRemapper) {
-        val remappedFields = mutableMapOf<String, String>()
-        val remappedMethods = mutableMapOf<String, String>()
-        val targetClassNames = MixinRemapper.getMixinClassTargets(classNode)
+    private fun remapField(field: FieldNode, remapper: KiltEnhancedRemapper, targetClassNames: Collection<String>): String? {
+        val annotations = KiltHelper.mergeNullableCollections(field.visibleAnnotations, field.invisibleAnnotations)
 
-        // Collect all shadow fields
-        for (field in classNode.fields) {
-            val annotations = KiltHelper.mergeNullableCollections(field.visibleAnnotations, field.invisibleAnnotations)
+        if (annotations.none { isTargeted(it) })
+            return null
 
-            if (annotations.none { isTargeted(it) })
-                continue
-
-            var remapped = ""
+        var remapped = ""
 
             for (className in targetClassNames) {
                 if (SPECIAL_REMAPS.contains(field.name)) {
@@ -44,46 +40,92 @@ object MixinShadowRemapper {
                 // First pass, try to remap with current names
                 remapped = remapper.mapFieldName(className, field.name, field.desc)
 
-                if (remapped != field.name)
-                    break
+            if (remapped != field.name)
+                break
 
-                // Second pass, try to remap with original names
-                remapped = remapper.mapFieldName(KiltRemapper.unmapClass(className), field.name, KiltRemapper.remapDescriptor(field.desc, reverse = true))
+            // Second pass, try to remap with original names
+            remapped = remapper.mapFieldName(KiltRemapper.unmapClass(className), field.name, KiltRemapper.remapDescriptor(field.desc, reverse = true))
 
-                if (remapped != field.name)
-                    break
-            }
+            if (remapped != field.name)
+                break
+        }
+        return remapped
+    }
+
+    private fun remapMethod(method: MethodNode, remapper: KiltEnhancedRemapper, targetClassNames: Collection<String>): String? {
+        val annotations = KiltHelper.mergeNullableCollections(method.visibleAnnotations, method.invisibleAnnotations)
+
+        if (annotations.none { isTargeted(it) })
+            return null
+
+        var remapped = ""
+
+        for (className in targetClassNames) {
+            // First pass, try to remap with original names
+            remapped = remapper.mapMethodName(className, method.name, method.desc)
+
+            if (remapped != method.name)
+                break
+
+            // Second pass, try to remap with original names
+            remapped = remapper.mapMethodName(KiltRemapper.unmapClass(className), method.name, KiltRemapper.remapDescriptor(method.desc, reverse = true))
+
+            if (remapped != method.name)
+                break
+        }
+        return remapped
+    }
+
+    private fun updateFieldsAndMethods(
+        classNode: ClassNode, remapper: KiltEnhancedRemapper,
+        remappedFields: MutableMap<String, String>,
+        remappedMethods: MutableMap<String, String>,
+        targetClassNames: Collection<String>,
+        unmappedParentMixinLookup: Map<String, ClassNode>, renameNodes: Boolean,
+    ) {
+        // Collect all shadow fields
+        for (field in classNode.fields) {
+            val remapped = remapField(field, remapper, targetClassNames) ?: continue
 
             remappedFields[field.name] = remapped
-            field.name = remapped
+            if (renameNodes) {
+                field.name = remapped
+            }
         }
-
         // Collect all shadow methods
         for (method in classNode.methods) {
-            val annotations = KiltHelper.mergeNullableCollections(method.visibleAnnotations, method.invisibleAnnotations)
-
-            if (annotations.none { isTargeted(it) })
-                continue
-
-            var remapped = ""
-
-            for (className in targetClassNames) {
-                // First pass, try to remap with original names
-                remapped = remapper.mapMethodName(className, method.name, method.desc)
-
-                if (remapped != method.name)
-                    break
-
-                // Second pass, try to remap with original names
-                remapped = remapper.mapMethodName(KiltRemapper.unmapClass(className), method.name, KiltRemapper.remapDescriptor(method.desc, reverse = true))
-
-                if (remapped != method.name)
-                    break
-            }
+            val remapped = remapMethod(method, remapper, targetClassNames) ?: continue
 
             remappedMethods[method.name] = remapped
-            method.name = remapped
+            if (renameNodes) {
+                method.name = remapped
+            }
         }
+
+        // Handle parent classes. We don't want to actually remap them here, but we want to collect any shadows they might contain.
+        if (classNode.superName != null) {
+            val superNode = unmappedParentMixinLookup[classNode.superName]
+            if (superNode != null) {
+                updateFieldsAndMethods(superNode, remapper, remappedFields, remappedMethods, targetClassNames, unmappedParentMixinLookup, false)
+            }
+        }
+        if (classNode.interfaces != null) {
+            for (iface in classNode.interfaces) {
+                val ifaceNode = unmappedParentMixinLookup[iface]
+                if (ifaceNode != null) {
+                    updateFieldsAndMethods(ifaceNode, remapper, remappedFields, remappedMethods, targetClassNames, unmappedParentMixinLookup, false)
+                }
+            }
+        }
+    }
+
+    fun remapClass(classNode: ClassNode, remapper: KiltEnhancedRemapper, unmappedParentMixinLookup: Map<String, ClassNode>) {
+        val remappedFields = mutableMapOf<String, String>()
+        val remappedMethods = mutableMapOf<String, String>()
+        val targetClassNames = MixinRemapper.getMixinClassTargets(classNode)
+
+        // Collect shadows in this class
+        updateFieldsAndMethods(classNode, remapper, remappedFields, remappedMethods, targetClassNames, unmappedParentMixinLookup, true)
 
         // Second pass, go through all the methods and point everything to the remapped shadows
         for (method in classNode.methods) {


### PR DESCRIPTION
Backports #816 and #793 to 1.20.1.