### PR TITLE
Add support for Forge mods written in Scala using Scalable Cat's Force

### DIFF
--- a/src/main/kotlin/com/kotori316/scala_lib/ScalaModContainer.kt
+++ b/src/main/kotlin/com/kotori316/scala_lib/ScalaModContainer.kt
@@ -1,0 +1,7 @@
+package com.kotori316.scala_lib
+
+import xyz.bluspring.kilt.loader.KiltModContainer
+import xyz.bluspring.kilt.loader.mod.ForgeMod
+
+class ScalaModContainer(mod: ForgeMod) : KiltModContainer(mod) {
+}

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -280,7 +280,7 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
         val modLoader = toml.get<String>("modLoader")
 
         // We need to check if the mod loader in the TOML is valid. Since we don't properly support ModLauncher or custom FML loading sequences, we need to implement support ourselves.
-        if (modLoader != "javafml" && modLoader != "lowcodefml" && modLoader != "kotlinforforge") {
+        if (modLoader != "javafml" && modLoader != "lowcodefml" && modLoader != "kotlinforforge" && modLoader != "kotori_scala") {
             throw IncompatibleModException("Forge mod file $fileName is not a supported FML mod! (got: $modLoader)")
         }
 
@@ -289,6 +289,19 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
             "kotlinforforge" -> {
                 if (!loaderVersionRange.containsVersion(Constants.KFF_VERSION)) {
                     throw IncompatibleModException("Forge mod file $fileName does not support Kotlin for Forge version ${Constants.KFF_VERSION}! (mod supports versions between [$loaderVersionRange])")
+                }
+            }
+
+            "kotori_scala" -> {
+                val scala = FabricLoader.getInstance().getModContainer("kotori_scala")
+                if (scala.isPresent) {
+                    val version = DefaultArtifactVersion(scala.get().metadata.version.friendlyString)
+                    if (!loaderVersionRange.containsVersion(version)) {
+                        // Some mods like OpenComputers might have a strict check, but we probably want to allow users to use the Fabric version which is probably more recent.
+                        KnitLoader.logger.warn("Forge mod file $fileName does not declare support for Scalable Cat's Force version ${version}! (mod supports versions between [$loaderVersionRange])")
+                    }
+                } else {
+                    throw IncompatibleModException("Kilt: You are missing Scalable Cat's Force! Please install the Fabric version of Scalable Cat's Force.")
                 }
             }
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltEarlyRiser.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltEarlyRiser.kt
@@ -468,7 +468,7 @@ class KiltEarlyRiser : Runnable {
         }
     }
 
-    private val ignoredKeywords = listOf("kilt", "fml", "mixin", "modlauncher", "kotlinforforge", "architectury", "versions")
+    private val ignoredKeywords = listOf("kilt", "fml", "mixin", "modlauncher", "kotlinforforge", "scala_lib", "architectury", "versions")
 
     // Required as Forge runs itself through ASM to fix events and ObjectHolders and such using ModLauncher.
     // So annoying.

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mod/ForgeMod.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mod/ForgeMod.kt
@@ -1,5 +1,6 @@
 package xyz.bluspring.kilt.loader.mod
 
+import com.kotori316.scala_lib.ScalaModContainer
 import cpw.mods.jarhandling.SecureJar
 import net.minecraftforge.eventbus.EventBusErrorMessage
 import net.minecraftforge.eventbus.api.BusBuilder
@@ -49,10 +50,12 @@ class ForgeMod(
 ) : KnitMod(definition), IModInfo {
     private val forgeDependencies = this.definition.dependencies.map { ForgeModDependency(it) }.toMutableList()
 
-    val container = if (definition.additionalData["loader"] == "kotlinforforge")
-        KotlinModContainer(this)
-    else
-        KiltModContainer(this)
+    val container = when (definition.additionalData["loader"]) {
+        "kotlinforforge" -> KotlinModContainer(this)
+        "kotori_scala" -> ScalaModContainer(this)
+        else -> KiltModContainer(this)
+    }
+
 
     lateinit var scanData: ModFileScanData
     lateinit var modObject: Any


### PR DESCRIPTION
Closes #868

I considered backporting the proper language loader changes from 1.21.1, but that quickly became a very big patch. We would also likely have needed to patch each language provider separately since they seem to depend heavily on modules in 1.20.1.

Plus, if we do it this way we can encourage users to use the Fabric version of Scalable Cat's Force. This is why the version check causes a warning instead of a crash (OpenComputers wants the exact version for some reason).