### PR TITLE
Add support for KotlinLangForge.

### DIFF
--- a/src/main/kotlin/dev/nyon/klf/KlfLoadingContext.kt
+++ b/src/main/kotlin/dev/nyon/klf/KlfLoadingContext.kt
@@ -1,0 +1,32 @@
+package dev.nyon.klf
+
+import net.minecraftforge.eventbus.api.IEventBus
+import net.minecraftforge.fml.ModLoadingContext
+import xyz.bluspring.kilt.loader.mod.ForgeMod
+import java.util.concurrent.ConcurrentHashMap
+
+@Suppress("unused")
+val MOD_BUS: IEventBus
+    get() {
+        return KlfLoadingContext.get().getKEventBus()
+    }
+
+class KlfLoadingContext(private val mod: ForgeMod) : ModLoadingContext() {
+    fun getKEventBus(): IEventBus {
+        return mod.eventBus
+    }
+
+    companion object {
+        private val cachedContexts = ConcurrentHashMap<String, KlfLoadingContext>()
+
+        fun kiltGetContext(mod: ForgeMod): KlfLoadingContext {
+            val ctx = cachedContexts.computeIfAbsent(mod.modId) { KlfLoadingContext(mod) }
+            ctx.setActiveContainer(mod.container)
+            return ctx
+        }
+
+        fun get(): KlfLoadingContext {
+            return ModLoadingContext.get().extension()
+        }
+    }
+}

--- a/src/main/kotlin/dev/nyon/klf/KotlinModContainer.kt
+++ b/src/main/kotlin/dev/nyon/klf/KotlinModContainer.kt
@@ -1,0 +1,7 @@
+package dev.nyon.klf
+
+import xyz.bluspring.kilt.loader.KiltModContainer
+import xyz.bluspring.kilt.loader.mod.ForgeMod
+
+class KotlinModContainer(mod: ForgeMod) : KiltModContainer(mod) {
+}

--- a/src/main/kotlin/net/minecraftforge/fml/ModLoadingContext.kt
+++ b/src/main/kotlin/net/minecraftforge/fml/ModLoadingContext.kt
@@ -1,5 +1,6 @@
 package net.minecraftforge.fml
 
+import dev.nyon.klf.KlfLoadingContext
 import net.minecraftforge.fml.config.IConfigSpec
 import net.minecraftforge.fml.config.ModConfig
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext
@@ -34,10 +35,11 @@ open class ModLoadingContext {
         }
 
     fun <T> extension(): T {
-        return if (this.kiltActiveContainer is KotlinModContainer)
-            (this as? KotlinModLoadingContext ?: KotlinModLoadingContext.kiltGetContext((this.kiltActiveContainer as KiltModContainer).mod)) as T
-        else
-            (this as? FMLJavaModLoadingContext ?: FMLJavaModLoadingContext.kiltGetContext((this.kiltActiveContainer as KiltModContainer).mod)) as T
+        return when(this.kiltActiveContainer) {
+            is KotlinModContainer -> (this as? KotlinModLoadingContext ?: KotlinModLoadingContext.kiltGetContext((this.kiltActiveContainer as KiltModContainer).mod)) as T
+            is dev.nyon.klf.KotlinModContainer -> (this as? KlfLoadingContext ?: KlfLoadingContext.kiltGetContext((this.kiltActiveContainer as KiltModContainer).mod)) as T
+            else -> (this as? FMLJavaModLoadingContext ?: FMLJavaModLoadingContext.kiltGetContext((this.kiltActiveContainer as KiltModContainer).mod)) as T
+        }
     }
 
     fun <T> registerExtensionPoint(point: Class<out IExtensionPoint<T>>, extension: Supplier<T>) where T : Record, T : IExtensionPoint<T> {

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/Constants.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/Constants.kt
@@ -8,6 +8,7 @@ object Constants {
 
     // Kotlin for Forge version. We're trying to emulate KFF.
     @JvmField val KFF_VERSION = DefaultArtifactVersion("4.12.0")
+    @JvmField val KLF_VERSION = DefaultArtifactVersion("2.12.1-k2.4.10-2.0+forge")
 
     const val KILT_ERROR_MESSAGE = "Kilt: Failed to start Kilt, please read the exception below!"
 }

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/KiltLoader.kt
@@ -6,6 +6,7 @@ import com.google.gson.JsonParser
 import com.mojang.serialization.JsonOps
 import cpw.mods.modlauncher.Launcher
 import cpw.mods.modlauncher.api.IEnvironment
+import dev.nyon.klf.KlfLoadingContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.filter
@@ -280,7 +281,7 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
         val modLoader = toml.get<String>("modLoader")
 
         // We need to check if the mod loader in the TOML is valid. Since we don't properly support ModLauncher or custom FML loading sequences, we need to implement support ourselves.
-        if (modLoader != "javafml" && modLoader != "lowcodefml" && modLoader != "kotlinforforge" && modLoader != "kotori_scala") {
+        if (modLoader != "javafml" && modLoader != "lowcodefml" && modLoader != "kotlinforforge" && modLoader != "kotori_scala" && modLoader != "klf") {
             throw IncompatibleModException("Forge mod file $fileName is not a supported FML mod! (got: $modLoader)")
         }
 
@@ -289,6 +290,12 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
             "kotlinforforge" -> {
                 if (!loaderVersionRange.containsVersion(Constants.KFF_VERSION)) {
                     throw IncompatibleModException("Forge mod file $fileName does not support Kotlin for Forge version ${Constants.KFF_VERSION}! (mod supports versions between [$loaderVersionRange])")
+                }
+            }
+
+            "klf" -> {
+                if (!loaderVersionRange.containsVersion(Constants.KLF_VERSION)) {
+                    throw IncompatibleModException("Forge mod file $fileName does not support KotlinLangForge version ${Constants.KLF_VERSION}! (mod supports versions between [$loaderVersionRange])")
                 }
             }
 
@@ -733,9 +740,15 @@ class KiltLoader : KnitModLoader<ForgeMod>(Kilt.MOD_ID, "Forge") {
                     val clazz = Class.forName(annotation.clazz.className, true, this::class.java.classLoader)
                     val obj = try { clazz.kotlin.objectInstance } catch (_: Throwable) { null }
 
-                    val bus = if (mod.container is KotlinModContainer && busType == Mod.EventBusSubscriber.Bus.MOD)
-                        KotlinModLoadingContext.get().getKEventBus()
-                    else busType.bus().get()
+                    val bus = if (busType == Mod.EventBusSubscriber.Bus.MOD) {
+                        when (mod.container) {
+                            is KotlinModContainer -> KotlinModLoadingContext.get().getKEventBus()
+                            is dev.nyon.klf.KotlinModContainer -> KlfLoadingContext.get().getKEventBus()
+                            else -> busType.bus().get()
+                        }
+                    } else {
+                        busType.bus().get()
+                    }
 
                     if (obj != null)
                         bus.register(obj)

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltEarlyRiser.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/asm/KiltEarlyRiser.kt
@@ -468,7 +468,7 @@ class KiltEarlyRiser : Runnable {
         }
     }
 
-    private val ignoredKeywords = listOf("kilt", "fml", "mixin", "modlauncher", "kotlinforforge", "scala_lib", "architectury", "versions")
+    private val ignoredKeywords = listOf("kilt", "fml", "mixin", "modlauncher", "kotlinforforge", "scala_lib", "klf", "architectury", "versions")
 
     // Required as Forge runs itself through ASM to fix events and ObjectHolders and such using ModLauncher.
     // So annoying.

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mod/ForgeMod.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mod/ForgeMod.kt
@@ -52,6 +52,7 @@ class ForgeMod(
 
     val container = when (definition.additionalData["loader"]) {
         "kotlinforforge" -> KotlinModContainer(this)
+        "klf" -> dev.nyon.klf.KotlinModContainer(this)
         "kotori_scala" -> ScalaModContainer(this)
         else -> KiltModContainer(this)
     }


### PR DESCRIPTION
Closes #877

KLF is just an alternative to KFF that some Forge mods use. Surveyor Atlases technically doesn't need this since the mod is Fabric native (it just bundles the Forge and Fabric versions in the same jar), but there are some Forge mods that use it. This patch does make Surveyor Atlases show up as a Forge mod in the game for some reason, but the mod itself seems to work as intended. Just like KFF I don't think we need to ask the user to download KLF since Kilt already depends on Fabric Language Kotlin.