### PR TITLE
Fix Deep Aether

### DIFF
--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
@@ -482,6 +482,31 @@ object KiltMixinModifications {
     val WRAP_OPERATION = register(
         WrapOperation::class.java,
 
+        // Fix Deep Aether's HumanoidArmorLayerMixin
+        ReplacedAnnotationsModifier(
+            owner = "net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer",
+            methods = listOf("renderArmorPiece(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;ILnet/minecraft/client/model/HumanoidModel;FFFFFF)V"),
+            variables = mapOf(
+                "at" to listOf(
+                    at(
+                        value = "INVOKE",
+                        target = "Lnet/minecraft/client/renderer/entity/layers/HumanoidArmorLayer;renderModel(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/model/Model;ILnet/minecraft/resources/ResourceLocation;)V"
+                    )
+                )
+            ),
+            replaceWith = listOf(
+                createAnnotation(WrapOperation::class.java, mapOf(
+                    "method" to "renderArmorPiece(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;ILnet/minecraft/client/model/HumanoidModel;)V",
+                    "at" to listOf(
+                        at(
+                            value = "INVOKE",
+                            target = "Lnet/minecraft/client/renderer/entity/layers/HumanoidArmorLayer;renderModel(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/model/HumanoidModel;ILnet/minecraft/resources/ResourceLocation;)V"
+                        )
+                    )
+                ))
+            )
+        ),
+
         // Fixes Create's ProjectileUtilMixin
         ReplacedAnnotationsModifier(
             owner = "net/minecraft/world/entity/projectile/ProjectileUtil",

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifications.kt
@@ -11,6 +11,7 @@ import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.MethodNode
 import org.spongepowered.asm.mixin.gen.Accessor
 import org.spongepowered.asm.mixin.injection.At
+import org.spongepowered.asm.mixin.injection.Coerce
 import org.spongepowered.asm.mixin.injection.Inject
 import org.spongepowered.asm.mixin.injection.ModifyVariable
 import org.spongepowered.asm.mixin.injection.Redirect
@@ -504,6 +505,23 @@ object KiltMixinModifications {
                         )
                     )
                 ))
+            )
+        ),
+        ParamAnnotationBasedModifier.AddParamAnnotationModifier(
+            owner = "net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer",
+            methods = listOf("renderArmorPiece(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;ILnet/minecraft/client/model/HumanoidModel;FFFFFF)V"),
+            variables = mapOf(
+                "at" to listOf(
+                    at(
+                        value = "INVOKE",
+                        target = "Lnet/minecraft/client/renderer/entity/layers/HumanoidArmorLayer;renderModel(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/model/Model;ILnet/minecraft/resources/ResourceLocation;)V"
+                    )
+                )
+            ),
+            params = mapOf(
+                ParamAnnotationBasedModifier.AddParamAnnotationModifier.ParamMatcher(
+                    type = "net/minecraft/client/model/Model"
+                ) to createAnnotation(Coerce::class.java, mapOf())
             )
         ),
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifier.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/KiltMixinModifier.kt
@@ -4,6 +4,7 @@ import com.bawnorton.mixinsquared.reflection.MixinInfoExtension
 import com.bawnorton.mixinsquared.reflection.StateExtension
 import com.bawnorton.mixinsquared.reflection.TargetClassContextExtension
 import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
 import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.InsnList
@@ -15,6 +16,7 @@ import org.spongepowered.asm.mixin.transformer.ext.ITargetClassContext
 import xyz.bluspring.kilt.Kilt
 import xyz.bluspring.kilt.loader.mixin.modifications.modifiers.AnnotationBasedModifier
 import xyz.bluspring.kilt.loader.mixin.modifications.modifiers.InjectedShareAccessModifier
+import xyz.bluspring.kilt.loader.mixin.modifications.modifiers.ParamAnnotationBasedModifier
 import xyz.bluspring.kilt.loader.remap.MixinTypes
 
 class KiltMixinModifier : IExtension {
@@ -40,6 +42,8 @@ class KiltMixinModifier : IExtension {
                 var wasModified = false
 
                 val replacedMethods = mutableMapOf<MethodNode, MethodNode>()
+
+                val paramModifiers = mutableListOf<ParamAnnotationBasedModifier>()
 
                 for (methodNode in mixinClassNode.methods) {
                     val annotations = methodNode.visibleAnnotations ?: continue
@@ -81,6 +85,10 @@ class KiltMixinModifier : IExtension {
 
                         for (modifier in modifiers) {
                             when (modifier) {
+                                is ParamAnnotationBasedModifier -> {
+                                    paramModifiers.add(modifier)
+                                }
+
                                 is AnnotationBasedModifier -> {
                                     modifier.modifyMixin(context.classInfo, annotation, newAnnotations)
                                     wasModified = true
@@ -99,6 +107,27 @@ class KiltMixinModifier : IExtension {
                         methodNode.visibleAnnotations = mutableListOf()
                         methodNode.visibleAnnotations.clear()
                         methodNode.visibleAnnotations.addAll(newAnnotations)
+                    }
+
+                    if (paramModifiers.isNotEmpty()) {
+                        val parameters = Type.getArgumentTypes(methodNode.desc)
+                        if (methodNode.invisibleParameterAnnotations == null) {
+                            methodNode.invisibleParameterAnnotations = arrayOfNulls(parameters.size)
+                        }
+                        for (i in parameters.indices) {
+                            val param = parameters[i]
+                            val annotations = mutableListOf<AnnotationNode>()
+                            if (methodNode.invisibleParameterAnnotations.size > i) {
+                                val toAdd: List<AnnotationNode>? = methodNode.invisibleParameterAnnotations[i]
+                                if (toAdd != null) {
+                                    annotations.addAll(toAdd)
+                                }
+                            }
+                            for (modifier in paramModifiers) {
+                                modifier.modifyMixinParams(context.classInfo, i, param, annotations)
+                            }
+                            methodNode.invisibleParameterAnnotations[i] = annotations
+                        }
                     }
                 }
 

--- a/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/ParamAnnotationBasedModifier.kt
+++ b/src/main/kotlin/xyz/bluspring/kilt/loader/mixin/modifications/modifiers/ParamAnnotationBasedModifier.kt
@@ -1,0 +1,54 @@
+package xyz.bluspring.kilt.loader.mixin.modifications.modifiers
+
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.AnnotationNode
+import org.spongepowered.asm.mixin.transformer.ClassInfo
+import xyz.bluspring.kilt.loader.remap.KiltRemapper
+
+interface ParamAnnotationBasedModifier : AnnotationBasedModifier {
+
+    fun modifyMixinParams(classInfo: ClassInfo, index: Int, parameter: Type, annotations: MutableList<AnnotationNode>)
+
+    override fun modifyMixin(classInfo: ClassInfo, annotation: AnnotationNode, newAnnotations: MutableList<AnnotationNode>) {
+        newAnnotations.add(annotation)
+    }
+
+    data class AddParamAnnotationModifier(
+        override val owner: String,
+        override val methods: List<String> = listOf(),
+        override val variables: Map<String, Any> = mapOf(),
+        val params: Map<ParamMatcher, AnnotationNode> = mapOf()
+    ) : ParamAnnotationBasedModifier {
+        override lateinit var mappedOwner: String
+        override lateinit var mappedMethods: List<String>
+
+        data class ParamMatcher(val index: Int? = null, private val type: String? = null) {
+            val mappedType = if (type != null) KiltRemapper.remapClass(type) else type
+
+            fun matches(index: Int, parameter: Type): Boolean {
+                if (this.index != null && this.index == index) {
+                    return true
+                }
+                if (this.mappedType != null && this.mappedType == parameter.internalName) {
+                    return true
+                }
+                return false
+            }
+        }
+
+        override fun modifyMixinParams(
+            classInfo: ClassInfo,
+            index: Int,
+            parameter: Type,
+            annotations: MutableList<AnnotationNode>
+        ) {
+            for ((param, annotation) in params) {
+                if (param.matches(index, parameter)) {
+                    annotations.add(annotation)
+                }
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
Adds some KiltMixinModification entries to make Deep Aether's [HumanoidArmorLayerMixin](https://github.com/RazorDevs/Deep-Aether/blob/1.21.1-1.1/src/main/java/io/github/razordevs/deep_aether/mixin/entity/HumanoidArmorLayerMixin.java) work.

To do this I needed way to add the `@Coerce` modifier to mixin method parameters since NeoForge has a different signature on the `renderModel` method.