### PR TITLE
Reduce size of Kilt JAR by around 20MB

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -257,10 +257,7 @@ val relocateCichlid = tasks.register<ShadowJar>("relocateCichlid") {
 
 dependencies {
     // Forge Reimplementations
-    val portingLibs = listOf("attributes", "base", "blocks", "brewing", "chunk_loading", "client_events", "client_extensions", "common", "config", "core", "data", "entity", "entity_data_serializers", "fluids", "gametest", "gui_utils", "item_abilities", "items", "level_events", "loot", "milk", "mixin_extensions", "model_data", "model_loader", "models", "obj_loader", "recipe_book_categories", "registry", "render_types", "resources", "tags", "transfer")
-    portingLibs.forEach { lib ->
-        modApi(include("io.github.fabricators_of_create.Porting-Lib:$lib:${property("porting_lib_version")}")!!)
-    }
+    modApi(include("io.github.fabricators_of_create.Porting-Lib:Porting-Lib:${property("porting_lib_version")}")!!)
 
     // JiJ'd into main JAR alone
     //include("io.github.llamalad7:mixinextras-fabric:${property("mixinextras_version")}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,7 @@ asmfabricloader_version=2.1.1-SNAPSHOT
 mixinconstraints_version=1.0.8
 
 # https://mvn.devos.one/#/snapshots/io/github/fabricators_of_create/Porting-Lib/base
-porting_lib_version=3.1.0-beta.87+1.21.1
+porting_lib_version=3.1.0+fat-jar
 
 # https://mvn.devos.one/#/snapshots/io/github/tropheusj/serialization-hooks
 # serialization_hooks_version=0.4.27


### PR DESCRIPTION
Warning
=======

- This change depends on https://github.com/Fabricators-of-Create/Porting-Lib/pull/201 being merged.

- The final Maven coordinates of the published artifact will likely change.

Explanation
==========

- Many of Porting Lib's modules include their own dependencies, and Loom does not have a method of deduplicating second-level nested dependencies as far as I know. This can lead to less than optimal file sizes for any mod that includes a lot of modules.

- I tested the functionality by building Porting Lib locally, and Kilt locally using the setup from this PR. I was able to get a Kilt build to around 16.5MB in size that worked flawlessly with the latest Twilight Forest NeoForge build. I have also tested building Twilight Forest on Fabric with a similar Porting Lib setup and was able to reduce the size of the built JAR by around 12MB.